### PR TITLE
[codex] Document hosted-web agent surfaces for Spuree skills

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,28 @@ Spuree provides an agent-friendly cloud storage via a simple Project → Folder 
 
 These skills are structured API documentation for AI agent consumption. Each skill documents a specific API domain with endpoints, request/response schemas, and working examples.
 
+## Agent Surfaces
+
+Each endpoint may include a hidden `spuree-agent` metadata block that tells MCP hosts where the endpoint is safe to expose:
+
+```md
+<!-- spuree-agent
+surfaces: ["local", "desktop", "backend", "hosted-web"]
+webSafe: true
+-->
+```
+
+Supported surfaces:
+
+| Surface | Meaning |
+| --- | --- |
+| `local` | Local CLI/agent runtimes that can access local files and follow returned URLs |
+| `desktop` | Desktop agent runtimes |
+| `backend` | Server-side automations |
+| `hosted-web` | Hosted web agents such as Claude Web connectors |
+
+Hosted web MCP clients should expose only endpoints with `hosted-web` in `surfaces` and `webSafe: true`. Endpoints that require local file bytes, direct S3 uploads, or fetching short-lived asset URLs should stay off the hosted-web surface unless there is a dedicated web-safe API.
+
 ## Installation
 
 ```bash

--- a/authentication/SKILL.md
+++ b/authentication/SKILL.md
@@ -77,20 +77,20 @@ The agent should show you which projects you have access to. If it works, your A
 
 Spuree uses two hosts:
 
-| Host | Purpose | Endpoints |
-| --- | --- | --- |
+| Host                            | Purpose                                   | Endpoints                                                    |
+| ------------------------------- | ----------------------------------------- | ------------------------------------------------------------ |
 | `https://studio.spuree.com/api` | Authentication (login, refresh, exchange) | `/auth/token`, `/auth/token/refresh`, `/auth/token/exchange` |
-| `https://data.spuree.com/api` | All V1 data APIs (projects, files, etc.) | `/v1/projects`, `/v1/files`, `/v1/api-keys`, ... |
+| `https://data.spuree.com/api`   | All V1 data APIs (projects, files, etc.)  | `/v1/projects`, `/v1/files`, `/v1/api-keys`, ...             |
 
 All other skills in this repo use `https://data.spuree.com/api`. Only the token endpoints below use `studio.spuree.com`.
 
 ## Token Lifecycle
 
-| Token | Lifetime | Format |
-| --- | --- | --- |
-| `access_token` | 1 hour | NextAuth JWT |
-| `refresh_token` | 30 days | Opaque hex string |
-| `exchange_code` | 60 seconds | Opaque string |
+| Token           | Lifetime   | Format            |
+| --------------- | ---------- | ----------------- |
+| `access_token`  | 1 hour     | NextAuth JWT      |
+| `refresh_token` | 30 days    | Opaque hex string |
+| `exchange_code` | 60 seconds | Opaque string     |
 
 The `access_token` is what you pass as `Authorization: Bearer <access_token>` to V1 API endpoints.
 
@@ -127,34 +127,40 @@ All three endpoints return the same OAuth2-compliant response:
 
 ### POST /auth/token
 
+<!-- spuree-agent
+surfaces: ["local", "desktop", "backend"]
+webSafe: false
+reason: "Hosted web MCP clients use the connector OAuth flow instead of collecting passwords or issuing raw JWTs."
+-->
+
 Log in with email and password.
 
 **Description:** Validates credentials and returns an access token and refresh token. Rate limited to 10 requests per minute per IP.
 
 **Request Body:**
 
-| Field | Type | Required | Description |
-| --- | --- | --- | --- |
-| `email` | string | Yes | User's email address |
-| `password` | string | Yes | User's password |
+| Field      | Type   | Required | Description          |
+| ---------- | ------ | -------- | -------------------- |
+| `email`    | string | Yes      | User's email address |
+| `password` | string | Yes      | User's password      |
 
 **Status Codes:**
 
-| Code | Description |
-| --- | --- |
-| 200 | Login successful, tokens returned |
-| 400 | Invalid request body or missing fields |
-| 401 | Invalid email or password, or account locked |
-| 429 | Rate limit exceeded (10 req/min) |
-| 500 | Internal server error |
+| Code | Description                                  |
+| ---- | -------------------------------------------- |
+| 200  | Login successful, tokens returned            |
+| 400  | Invalid request body or missing fields       |
+| 401  | Invalid email or password, or account locked |
+| 429  | Rate limit exceeded (10 req/min)             |
+| 500  | Internal server error                        |
 
 **Error Messages (401):**
 
-| Message | Cause |
-| --- | --- |
-| `Invalid email or password` | Wrong credentials |
-| `Password is not set for this user` | User registered via OAuth only |
-| `Account is temporarily locked...` | Too many failed attempts (5 failures → 15 min lock) |
+| Message                             | Cause                                               |
+| ----------------------------------- | --------------------------------------------------- |
+| `Invalid email or password`         | Wrong credentials                                   |
+| `Password is not set for this user` | User registered via OAuth only                      |
+| `Account is temporarily locked...`  | Too many failed attempts (5 failures → 15 min lock) |
 
 **Example:**
 
@@ -171,25 +177,31 @@ curl -X POST "https://studio.spuree.com/api/auth/token" \
 
 ### POST /auth/token/refresh
 
+<!-- spuree-agent
+surfaces: ["local", "desktop", "backend"]
+webSafe: false
+reason: "Hosted web MCP clients refresh through the connector OAuth flow, not an exposed token-refresh tool."
+-->
+
 Refresh an expired access token.
 
 **Description:** Exchanges a valid refresh token for a new access token and refresh token pair. The old refresh token is atomically revoked to prevent reuse. Rate limited to 10 requests per minute per IP.
 
 **Request Body:**
 
-| Field | Type | Required | Description |
-| --- | --- | --- | --- |
-| `refresh_token` | string | Yes | The refresh token from a previous login or refresh |
+| Field           | Type   | Required | Description                                        |
+| --------------- | ------ | -------- | -------------------------------------------------- |
+| `refresh_token` | string | Yes      | The refresh token from a previous login or refresh |
 
 **Status Codes:**
 
-| Code | Description |
-| --- | --- |
-| 200 | New tokens issued |
-| 400 | Missing refresh token |
-| 401 | Invalid or expired refresh token |
-| 429 | Rate limit exceeded |
-| 500 | Internal server error |
+| Code | Description                      |
+| ---- | -------------------------------- |
+| 200  | New tokens issued                |
+| 400  | Missing refresh token            |
+| 401  | Invalid or expired refresh token |
+| 429  | Rate limit exceeded              |
+| 500  | Internal server error            |
 
 **Example:**
 
@@ -210,25 +222,31 @@ curl -X POST "https://studio.spuree.com/api/auth/token/refresh" \
 
 ### POST /auth/token/exchange
 
+<!-- spuree-agent
+surfaces: ["local", "desktop", "backend"]
+webSafe: false
+reason: "This is a local/browser login exchange flow and is not part of the hosted web MCP surface."
+-->
+
 Exchange an authorization code for tokens.
 
 **Description:** Exchanges a one-time authorization code for an access token and refresh token. Used by agents and desktop apps that authenticate via the browser (see Getting Started Option C). The login flow starts at `studio.spuree.com/auth/signin?source=api` — after the user completes login, the exchange code is delivered to the agent's local callback server. Rate limited to 10 requests per minute per IP.
 
 **Request Body:**
 
-| Field | Type | Required | Description |
-| --- | --- | --- | --- |
-| `code` | string | Yes | The authorization exchange code |
+| Field  | Type   | Required | Description                     |
+| ------ | ------ | -------- | ------------------------------- |
+| `code` | string | Yes      | The authorization exchange code |
 
 **Status Codes:**
 
-| Code | Description |
-| --- | --- |
-| 200 | Tokens issued |
-| 400 | Missing exchange code |
-| 401 | Invalid or expired exchange code |
-| 429 | Rate limit exceeded |
-| 500 | Internal server error |
+| Code | Description                      |
+| ---- | -------------------------------- |
+| 200  | Tokens issued                    |
+| 400  | Missing exchange code            |
+| 401  | Invalid or expired exchange code |
+| 429  | Rate limit exceeded              |
+| 500  | Internal server error            |
 
 **Example:**
 
@@ -253,17 +271,23 @@ All V1 endpoints accept either `Authorization: Bearer <jwt>` or `X-API-Key: <api
 
 ### POST /v1/api-keys
 
+<!-- spuree-agent
+surfaces: ["local", "desktop", "backend"]
+webSafe: false
+reason: "Creating long-lived API keys is not exposed to hosted web MCP clients."
+-->
+
 Create a new API key.
 
 **Auth:** Requires JWT (Bearer token only, not API key).
 
 **Request Body:**
 
-| Field | Type | Required | Description |
-| --- | --- | --- | --- |
-| `name` | string | Yes | Descriptive name for the key |
-| `scopes` | object | No | `{ "organizations": ["orgId1", ...] }` — restrict to specific orgs. Omit for all orgs. |
-| `expiresAt` | datetime | No | Expiration timestamp (ISO 8601). Omit for no expiry. |
+| Field       | Type     | Required | Description                                                                            |
+| ----------- | -------- | -------- | -------------------------------------------------------------------------------------- |
+| `name`      | string   | Yes      | Descriptive name for the key                                                           |
+| `scopes`    | object   | No       | `{ "organizations": ["orgId1", ...] }` — restrict to specific orgs. Omit for all orgs. |
+| `expiresAt` | datetime | No       | Expiration timestamp (ISO 8601). Omit for no expiry.                                   |
 
 **Response:**
 
@@ -298,6 +322,12 @@ curl -X POST "https://data.spuree.com/api/v1/api-keys" \
 
 ### GET /v1/api-keys
 
+<!-- spuree-agent
+surfaces: ["local", "desktop", "backend"]
+webSafe: false
+reason: "API key management is not exposed to hosted web MCP clients."
+-->
+
 List all active API keys for the authenticated user.
 
 **Auth:** Requires JWT (Bearer token only).
@@ -328,6 +358,12 @@ curl "https://data.spuree.com/api/v1/api-keys" \
 ---
 
 ### DELETE /v1/api-keys/{key_id}
+
+<!-- spuree-agent
+surfaces: ["local", "desktop", "backend"]
+webSafe: false
+reason: "API key management is not exposed to hosted web MCP clients."
+-->
 
 Revoke an API key (soft delete).
 
@@ -406,13 +442,13 @@ API keys don't expire by default (unless `expiresAt` is set) and don't need refr
 
 ## Error Handling
 
-| Error | Cause | Resolution |
-| --- | --- | --- |
-| 401 (invalid credentials) | Wrong email or password | Verify credentials |
-| 401 (account locked) | 5 failed login attempts | Wait 15 minutes, then retry |
-| 401 (invalid refresh token) | Token expired, revoked, or reused | Log in again with email/password |
-| 401 (invalid exchange code) | Code expired or already used | Request a new exchange code |
-| 429 (rate limit) | More than 10 requests/min from same IP | Wait and retry with backoff |
+| Error                       | Cause                                  | Resolution                       |
+| --------------------------- | -------------------------------------- | -------------------------------- |
+| 401 (invalid credentials)   | Wrong email or password                | Verify credentials               |
+| 401 (account locked)        | 5 failed login attempts                | Wait 15 minutes, then retry      |
+| 401 (invalid refresh token) | Token expired, revoked, or reused      | Log in again with email/password |
+| 401 (invalid exchange code) | Code expired or already used           | Request a new exchange code      |
+| 429 (rate limit)            | More than 10 requests/min from same IP | Wait and retry with backoff      |
 
 ## Rate Limits
 

--- a/file-management/SKILL.md
+++ b/file-management/SKILL.md
@@ -27,25 +27,30 @@ Or: `X-API-Key: $SPUREE_API_KEY`. See the **authentication** skill.
 
 ## Base URLs
 
-| Base URL | Endpoints |
-| --- | --- |
-| `https://data.spuree.com/api/v1/files` | File CRUD |
+| Base URL                                | Endpoints            |
+| --------------------------------------- | -------------------- |
+| `https://data.spuree.com/api/v1/files`  | File CRUD            |
 | `https://data.spuree.com/api/v1/search` | Cross-project search |
 
 ## Endpoints
 
 ### GET /v1/search
 
+<!-- spuree-agent
+surfaces: ["local", "desktop", "backend", "hosted-web"]
+webSafe: true
+-->
+
 Search files and folders by name (case-insensitive substring match). Returns sessions first, then files.
 
 **Query Parameters:**
 
-| Parameter | Type | Default | Description |
-| --- | --- | --- | --- |
-| `q` | string | — | Search query (1–255 chars) |
-| `type` | string | — | Filter: `"file"` or `"session"`. Omit for both. |
-| `workspaceId` | string | — | Restrict results to a specific workspace |
-| `limit` | integer | 100 | Max results (1–100) |
+| Parameter     | Type    | Default | Description                                     |
+| ------------- | ------- | ------- | ----------------------------------------------- |
+| `q`           | string  | —       | Search query (1–255 chars)                      |
+| `type`        | string  | —       | Filter: `"file"` or `"session"`. Omit for both. |
+| `workspaceId` | string  | —       | Restrict results to a specific workspace        |
+| `limit`       | integer | 100     | Max results (1–100)                             |
 
 **Response:** `{ "data": [...], "count": N }`
 
@@ -63,6 +68,12 @@ curl "https://data.spuree.com/api/v1/search?q=hero" \
 
 ### GET /v1/files/{fileId}
 
+<!-- spuree-agent
+surfaces: ["local", "desktop", "backend"]
+webSafe: true
+reason: "Returns a short-lived CloudFront download URL that hosted web agents may not be able to fetch."
+-->
+
 Get file metadata and presigned download URL.
 
 **Response:** `{ "data": { id, fileName, fileFormat, mimeType, size, workspaceId, sessionId, entitySessionId, downloadUrl, createdAt, updatedAt } }`
@@ -74,7 +85,39 @@ curl "https://data.spuree.com/api/v1/files/{fileId}" \
 
 ---
 
+### GET /v1/files/{fileId}/content
+
+<!-- spuree-agent
+surfaces: ["local", "desktop", "backend", "hosted-web"]
+webSafe: true
+-->
+
+Get inline UTF-8 text content for a small text-like file. Use this when an agent needs to read markdown, text, JSON, CSV, YAML, XML, subtitles, logs, or source files directly instead of following a short-lived CloudFront download URL.
+
+This endpoint is not a replacement for file downloads. Binary files and large files should still use `GET /v1/files/{fileId}` and its `downloadUrl`.
+
+**Response:** `{ "data": { id, fileName, fileFormat, mimeType, size, encoding, content, truncated } }`
+
+| Code | Description                                |
+| ---- | ------------------------------------------ |
+| 200  | Text content returned                      |
+| 413  | File is too large to return inline         |
+| 415  | Unsupported/binary format or invalid UTF-8 |
+
+```bash
+curl "https://data.spuree.com/api/v1/files/{fileId}/content" \
+  -H "Authorization: Bearer $SPUREE_ACCESS_TOKEN"
+```
+
+---
+
 ### POST /v1/files
+
+<!-- spuree-agent
+surfaces: ["local", "desktop", "backend"]
+webSafe: false
+reason: "Starts a direct S3 upload flow that requires the client to upload local file bytes to a presigned URL."
+-->
 
 Create a file record and get presigned upload URL(s). Automatically selects upload mode based on file size:
 
@@ -85,23 +128,23 @@ The caller **must** then upload to S3 **and** call `POST /v1/files/{fileId}/uplo
 
 **Request Body:**
 
-| Field | Type | Required | Description |
-| --- | --- | --- | --- |
-| `fileName` | string | Yes | File name without extension |
-| `fileFormat` | string | Yes | Extension in lowercase (e.g., `fbx`, `png`) |
-| `fileSize` | integer | Yes | File size in bytes (accepts string for backward compat) |
-| `sessionId` | string | Yes | Target project or folder ObjectId |
-| `checksum` | string | No | CRC32 base64 (8 chars) for end-to-end verification. When provided, the presigned URL is signed with the checksum and S3 verifies the upload matches. |
+| Field        | Type    | Required | Description                                                                                                                                          |
+| ------------ | ------- | -------- | ---------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `fileName`   | string  | Yes      | File name without extension                                                                                                                          |
+| `fileFormat` | string  | Yes      | Extension in lowercase (e.g., `fbx`, `png`)                                                                                                          |
+| `fileSize`   | integer | Yes      | File size in bytes (accepts string for backward compat)                                                                                              |
+| `sessionId`  | string  | Yes      | Target project or folder ObjectId                                                                                                                    |
+| `checksum`   | string  | No       | CRC32 base64 (8 chars) for end-to-end verification. When provided, the presigned URL is signed with the checksum and S3 verifies the upload matches. |
 
 **Response (single mode):** `{ messageCode, fileId, mode: "single", uploadUrl, checksumBase64, contentType }`
 
 **Response (multipart mode):** `{ messageCode, fileId, mode: "multipart", parts: [{partNumber, startByte, endByte, url}, ...], totalParts, expiresAt }`
 
-| Code | Description |
-| --- | --- |
-| 200 | Record created, presigned URL(s) returned |
-| 404 | Session not found |
-| 409 | File already exists |
+| Code | Description                               |
+| ---- | ----------------------------------------- |
+| 200  | Record created, presigned URL(s) returned |
+| 404  | Session not found                         |
+| 409  | File already exists                       |
 
 ```bash
 curl -X POST "https://data.spuree.com/api/v1/files" \
@@ -114,14 +157,20 @@ curl -X POST "https://data.spuree.com/api/v1/files" \
 
 ### POST /v1/files/{fileId}/upload/complete
 
+<!-- spuree-agent
+surfaces: ["local", "desktop", "backend"]
+webSafe: false
+reason: "Completes a direct S3 upload flow that hosted web agents cannot perform end to end."
+-->
+
 Mark a file upload as completed. Works for both single and multipart uploads — the server auto-detects by checking whether the file has an active multipart `uploadId`. For multipart, the server calls S3 `ListParts` to collect ETags and then `CompleteMultipartUpload`.
 
 **Request Body:**
 
-| Field | Type | Required | Description |
-| --- | --- | --- | --- |
-| `fileId` | string | Yes | Must match path parameter |
-| `clientChecksumCRC32` | string | No | Client-computed CRC32 for end-to-end verification |
+| Field                 | Type   | Required | Description                                       |
+| --------------------- | ------ | -------- | ------------------------------------------------- |
+| `fileId`              | string | Yes      | Must match path parameter                         |
+| `clientChecksumCRC32` | string | No       | Client-computed CRC32 for end-to-end verification |
 
 **Response:** `{ messageCode, fileId, checksum, checksumCRC32 }`
 
@@ -139,23 +188,28 @@ curl -X POST "https://data.spuree.com/api/v1/files/{fileId}/upload/complete" \
 
 ### PATCH /v1/files/{fileId}
 
+<!-- spuree-agent
+surfaces: ["local", "desktop", "backend", "hosted-web"]
+webSafe: true
+-->
+
 Update file metadata. At least one field required.
 
-| Field | Type | Description |
-| --- | --- | --- |
-| `fileName` | string | New name (without extension) |
-| `fileFormat` | string | New extension (lowercase) |
-| `checksum` | string | CRC32 base64 (write-once backfill, no edit permission needed) |
-| `sessionId` | string | Move to target project or folder |
+| Field        | Type   | Description                                                   |
+| ------------ | ------ | ------------------------------------------------------------- |
+| `fileName`   | string | New name (without extension)                                  |
+| `fileFormat` | string | New extension (lowercase)                                     |
+| `checksum`   | string | CRC32 base64 (write-once backfill, no edit permission needed) |
+| `sessionId`  | string | Move to target project or folder                              |
 
 **Move:** Only `creative_project` (project) and `session` (folder) targets supported.
 
 **Response:** `{ messageCode, fileId }`
 
-| Code | Description |
-| --- | --- |
-| 200 | Updated |
-| 409 | Filename conflict in target |
+| Code | Description                 |
+| ---- | --------------------------- |
+| 200  | Updated                     |
+| 409  | Filename conflict in target |
 
 ```bash
 curl -X PATCH "https://data.spuree.com/api/v1/files/{fileId}" \
@@ -168,15 +222,21 @@ curl -X PATCH "https://data.spuree.com/api/v1/files/{fileId}" \
 
 ### PUT /v1/files/{fileId}
 
+<!-- spuree-agent
+surfaces: ["local", "desktop", "backend"]
+webSafe: false
+reason: "Starts a content replacement upload that requires local file bytes and presigned S3 upload URLs."
+-->
+
 Prepare a content update with optimistic concurrency. Acquires an upload lock. Like `POST /v1/files`, automatically selects single or multipart mode based on `fileSize`.
 
 **Request Body:**
 
-| Field | Type | Required | Description |
-| --- | --- | --- | --- |
-| `expectedChecksum` | string | Yes | CRC32 base64 of current content (for conflict detection) |
-| `newChecksum` | string | Yes | CRC32 base64 of new content to upload |
-| `fileSize` | integer | No | Size in bytes. If ≥ 100 MB, returns multipart mode. |
+| Field              | Type    | Required | Description                                              |
+| ------------------ | ------- | -------- | -------------------------------------------------------- |
+| `expectedChecksum` | string  | Yes      | CRC32 base64 of current content (for conflict detection) |
+| `newChecksum`      | string  | Yes      | CRC32 base64 of new content to upload                    |
+| `fileSize`         | integer | No       | Size in bytes. If ≥ 100 MB, returns multipart mode.      |
 
 **Response (single):** `{ messageCode, fileId, mode: "single", uploadUrl, checksumBase64, contentType }`
 
@@ -186,10 +246,10 @@ After receiving the response, upload to S3 then call `POST /v1/files/{fileId}/up
 
 **Upload lock:** Single uploads lock for 1 hour. Multipart uploads lock for 6 hours. Same user can re-acquire. Expired locks auto-release.
 
-| Code | Description |
-| --- | --- |
-| 200 | Lock acquired, presigned URL(s) returned |
-| 409 | Checksum mismatch or locked by another user |
+| Code | Description                                 |
+| ---- | ------------------------------------------- |
+| 200  | Lock acquired, presigned URL(s) returned    |
+| 409  | Checksum mismatch or locked by another user |
 
 ```bash
 curl -X PUT "https://data.spuree.com/api/v1/files/{fileId}" \
@@ -202,22 +262,28 @@ curl -X PUT "https://data.spuree.com/api/v1/files/{fileId}" \
 
 ### GET /v1/files/{fileId}/upload
 
+<!-- spuree-agent
+surfaces: ["local", "desktop", "backend"]
+webSafe: false
+reason: "Resumes a multipart upload flow that hosted web agents cannot complete without local file byte access."
+-->
+
 Resume a multipart upload. Returns which parts are already in S3 and fresh presigned URLs for remaining parts.
 
 **Query Parameters:**
 
-| Parameter | Type | Required | Description |
-| --- | --- | --- | --- |
-| `uploadId` | string | No | Client's expected uploadId for mismatch detection |
-| `checksum` | string | No | Client's expected pendingChecksum for conflict detection |
+| Parameter  | Type   | Required | Description                                              |
+| ---------- | ------ | -------- | -------------------------------------------------------- |
+| `uploadId` | string | No       | Client's expected uploadId for mismatch detection        |
+| `checksum` | string | No       | Client's expected pendingChecksum for conflict detection |
 
 **Response:** `{ messageCode, fileId, completedParts: [{partNumber, etag, size}, ...], remainingParts: [{partNumber, startByte, endByte, url}, ...], totalParts }`
 
-| Code | Description |
-| --- | --- |
-| 200 | Success |
-| 400 | No active multipart upload |
-| 409 | Not in pending status or locked by another user |
+| Code | Description                                     |
+| ---- | ----------------------------------------------- |
+| 200  | Success                                         |
+| 400  | No active multipart upload                      |
+| 409  | Not in pending status or locked by another user |
 
 ```bash
 curl "https://data.spuree.com/api/v1/files/{fileId}/upload" \
@@ -228,16 +294,22 @@ curl "https://data.spuree.com/api/v1/files/{fileId}/upload" \
 
 ### POST /v1/files/{fileId}/upload/urls
 
+<!-- spuree-agent
+surfaces: ["local", "desktop", "backend"]
+webSafe: false
+reason: "Refreshes presigned URLs for a direct multipart upload flow."
+-->
+
 Refresh presigned URLs for specific parts of a multipart upload. Use when URLs have expired before upload completes.
 
 **Request Body:** `{ "partNumbers": [1, 3, 5] }` (1-indexed, min 1 part)
 
 **Response:** `{ messageCode, urls: [{partNumber, startByte, endByte, url}, ...] }`
 
-| Code | Description |
-| --- | --- |
-| 200 | Success |
-| 400 | No active multipart upload or invalid part numbers |
+| Code | Description                                        |
+| ---- | -------------------------------------------------- |
+| 200  | Success                                            |
+| 400  | No active multipart upload or invalid part numbers |
 
 ```bash
 curl -X POST "https://data.spuree.com/api/v1/files/{fileId}/upload/urls" \
@@ -250,14 +322,20 @@ curl -X POST "https://data.spuree.com/api/v1/files/{fileId}/upload/urls" \
 
 ### DELETE /v1/files/{fileId}/upload
 
+<!-- spuree-agent
+surfaces: ["local", "desktop", "backend"]
+webSafe: false
+reason: "Cancels a direct upload workflow rather than a normal hosted-web file action."
+-->
+
 Abort a multipart upload. Cleans up S3 parts and marks the file as failed. Idempotent — safe to call on already-aborted uploads.
 
 **Response:** `{ messageCode, fileId, message }`
 
-| Code | Description |
-| --- | --- |
-| 200 | Aborted |
-| 400 | No active multipart upload |
+| Code | Description                |
+| ---- | -------------------------- |
+| 200  | Aborted                    |
+| 400  | No active multipart upload |
 
 ```bash
 curl -X DELETE "https://data.spuree.com/api/v1/files/{fileId}/upload" \
@@ -267,6 +345,11 @@ curl -X DELETE "https://data.spuree.com/api/v1/files/{fileId}/upload" \
 ---
 
 ### DELETE /v1/files/{fileId}
+
+<!-- spuree-agent
+surfaces: ["local", "desktop", "backend", "hosted-web"]
+webSafe: true
+-->
 
 Soft-delete a file.
 
@@ -282,17 +365,20 @@ curl -X DELETE "https://data.spuree.com/api/v1/files/{fileId}" \
 ### Single Upload Flow (< 100 MB)
 
 1. **Compute CRC32 checksum (base64):**
+
    ```bash
    CHECKSUM=$(python3 -c "import base64, zlib, sys; print(base64.b64encode(zlib.crc32(open('$FILE_PATH','rb').read()).to_bytes(4,'big')).decode())")
    ```
 
 2. **Create file record** — `sessionId` is the target project or folder:
+
    ```
    POST /v1/files { fileName, fileFormat, fileSize, sessionId, checksum }
    → { fileId, mode: "single", uploadUrl, checksumBase64, contentType }
    ```
 
 3. **Upload binary to S3:**
+
    ```
    PUT {uploadUrl}
    Content-Type: {contentType}
@@ -310,12 +396,14 @@ curl -X DELETE "https://data.spuree.com/api/v1/files/{fileId}" \
 ### Multipart Upload Flow (≥ 100 MB)
 
 1. **Create file record** with `fileSize` ≥ 100 MB:
+
    ```
    POST /v1/files { fileName, fileFormat, fileSize, sessionId, checksum }
    → { fileId, mode: "multipart", parts: [{partNumber, startByte, endByte, url}, ...], totalParts, expiresAt }
    ```
 
 2. **Upload each part** to its presigned URL:
+
    ```
    PUT {part.url}
    Content-Length: {part.endByte - part.startByte + 1}
@@ -327,6 +415,7 @@ curl -X DELETE "https://data.spuree.com/api/v1/files/{fileId}" \
 4. **If URLs expire**, refresh with `POST /v1/files/{fileId}/upload/urls` for specific parts.
 
 5. **Complete** — server auto-detects multipart and calls S3 `CompleteMultipartUpload`:
+
    ```
    POST /v1/files/{fileId}/upload/complete
    ```
@@ -344,6 +433,7 @@ curl -X DELETE "https://data.spuree.com/api/v1/files/{fileId}" \
 When a user wants to **view**, **preview**, or **see** a file:
 
 1. If the agent has browser tools (e.g., Chrome DevTools MCP), **open the Studio preview URL directly**:
+
    ```
    navigate_page → https://studio.spuree.com/file/{fileId}
    ```
@@ -355,10 +445,10 @@ When a user wants to **view**, **preview**, or **see** a file:
 
 Do **not** download the file or attempt to open it locally. The Studio URL is permanent, permission-aware, and renders images, video, 3D, and other supported formats inline in the browser.
 
-| Use case | URL | Properties |
-| --- | --- | --- |
-| **Share with user / preview** | `https://studio.spuree.com/file/{fileId}` | Permanent, permission-aware, renders preview UI |
-| **Programmatic download** | `downloadUrl` from `GET /v1/files/{fileId}` | Short-lived presigned S3 URL — do not share, bypasses permissions and expires |
+| Use case                      | URL                                         | Properties                                                                    |
+| ----------------------------- | ------------------------------------------- | ----------------------------------------------------------------------------- |
+| **Share with user / preview** | `https://studio.spuree.com/file/{fileId}`   | Permanent, permission-aware, renders preview UI                               |
+| **Programmatic download**     | `downloadUrl` from `GET /v1/files/{fileId}` | Short-lived presigned S3 URL — do not share, bypasses permissions and expires |
 
 **Rule of thumb:** after `POST /v1/files` (upload) or `GET /v1/search`, build the Studio URL from the returned `fileId` and return that to the user. Only fetch `downloadUrl` when the agent itself needs the bytes.
 
@@ -376,21 +466,21 @@ S3 key: `works_{workspaceId}/sess_{sessionId}/file_{fileId}`
 
 ### Studio URLs
 
-| Resource | URL Pattern |
-| --- | --- |
-| Project | `https://studio.spuree.com/projects/{projectId}` |
+| Resource           | URL Pattern                                                         |
+| ------------------ | ------------------------------------------------------------------- |
+| Project            | `https://studio.spuree.com/projects/{projectId}`                    |
 | Folder (top-level) | `https://studio.spuree.com/projects/{projectId}/folders/{folderId}` |
-| Folder (nested) | `.../folders/{parentId}/{childId}` (up to 5 levels) |
-| File | `https://studio.spuree.com/file/{fileId}` |
+| Folder (nested)    | `.../folders/{parentId}/{childId}` (up to 5 levels)                 |
+| File               | `https://studio.spuree.com/file/{fileId}`                           |
 
 ## Error Handling
 
-| Code | Cause | Resolution |
-| --- | --- | --- |
-| 400 | Invalid checksum format, missing fields, bad ID | Fix input format |
-| 403 | No workspace access or edit permission | Check permissions |
-| 404 | File or session not found | Verify IDs |
-| 409 (checksum mismatch) | File modified by another user | Re-fetch checksum, retry |
-| 409 (upload lock) | Another user is uploading | Wait (lock expires in 1 hour for single, 6 hours for multipart) |
-| 409 (filename conflict) | Same name exists in target | Use different name or target |
-| 401 | Invalid or expired token | Refresh via **authentication** skill |
+| Code                    | Cause                                           | Resolution                                                      |
+| ----------------------- | ----------------------------------------------- | --------------------------------------------------------------- |
+| 400                     | Invalid checksum format, missing fields, bad ID | Fix input format                                                |
+| 403                     | No workspace access or edit permission          | Check permissions                                               |
+| 404                     | File or session not found                       | Verify IDs                                                      |
+| 409 (checksum mismatch) | File modified by another user                   | Re-fetch checksum, retry                                        |
+| 409 (upload lock)       | Another user is uploading                       | Wait (lock expires in 1 hour for single, 6 hours for multipart) |
+| 409 (filename conflict) | Same name exists in target                      | Use different name or target                                    |
+| 401                     | Invalid or expired token                        | Refresh via **authentication** skill                            |

--- a/folder-management/SKILL.md
+++ b/folder-management/SKILL.md
@@ -74,6 +74,11 @@ Entities represent assets and have one of these types:
 
 ### POST /v1/sessions
 
+<!-- spuree-agent
+surfaces: ["local", "desktop", "backend", "hosted-web"]
+webSafe: true
+-->
+
 Create a new folder.
 
 **Description:** Creates a folder under a parent (project, folder, animation, or entity). The name must be compatible with Windows file system naming rules.
@@ -130,6 +135,11 @@ curl -X POST "https://data.spuree.com/api/v1/sessions" \
 ---
 
 ### PATCH /v1/sessions/{sessionId}
+
+<!-- spuree-agent
+surfaces: ["local", "desktop", "backend", "hosted-web"]
+webSafe: true
+-->
 
 Update a folder (rename, move, or edit tags).
 
@@ -196,6 +206,11 @@ curl -X PATCH "https://data.spuree.com/api/v1/sessions/64a7b8c9d1e2f3a4b5c6d7e8"
 
 ### DELETE /v1/sessions/{sessionId}
 
+<!-- spuree-agent
+surfaces: ["local", "desktop", "backend", "hosted-web"]
+webSafe: true
+-->
+
 Delete a folder (soft delete).
 
 **Description:** Soft-deletes a folder by setting its status to "deleted". Only folders (`sessionType: "session"`) can be deleted via this endpoint.
@@ -236,6 +251,11 @@ curl -X DELETE "https://data.spuree.com/api/v1/sessions/64a7b8c9d1e2f3a4b5c6d7e8
 ---
 
 ### GET /v1/sessions/{sessionId}/children
+
+<!-- spuree-agent
+surfaces: ["local", "desktop", "backend", "hosted-web"]
+webSafe: true
+-->
 
 Browse a folder's immediate contents.
 
@@ -353,6 +373,11 @@ curl "https://data.spuree.com/api/v1/sessions/64a7b8c9d1e2f3a4b5c6d7e8/children?
 
 ### GET /v1/sessions/{sessionId}/assets
 
+<!-- spuree-agent
+surfaces: ["local", "desktop", "backend", "hosted-web"]
+webSafe: true
+-->
+
 Get assets (entities) in a folder.
 
 **Description:** Returns entity sessions and their associated files for a given folder.
@@ -421,6 +446,11 @@ curl "https://data.spuree.com/api/v1/sessions/64a7b8c9d1e2f3a4b5c6d7e8/assets" \
 
 ### GET /v1/sessions/{sessionId}/files
 
+<!-- spuree-agent
+surfaces: ["local", "desktop", "backend", "hosted-web"]
+webSafe: true
+-->
+
 Get files in a folder.
 
 **Description:** Returns files associated with a folder. By default, flattens results to include files from sub-folders via entity session linkage.
@@ -488,6 +518,12 @@ curl "https://data.spuree.com/api/v1/sessions/64a7b8c9d1e2f3a4b5c6d7e8/files?fla
 ---
 
 ### POST /v1/sessions/files/download/urls
+
+<!-- spuree-agent
+surfaces: ["local", "desktop", "backend"]
+webSafe: false
+reason: "Returns short-lived S3/CloudFront download URLs that hosted web agents may not be able to fetch."
+-->
 
 Get download URLs for multiple files in bulk.
 

--- a/project-invitation/SKILL.md
+++ b/project-invitation/SKILL.md
@@ -63,6 +63,11 @@ https://data.spuree.com/api/v1/projects
 
 ### GET /v1/projects/invitations/pending
 
+<!-- spuree-agent
+surfaces: ["local", "desktop", "backend", "hosted-web"]
+webSafe: true
+-->
+
 List pending invitations for the current user.
 
 **Response:** `{ "invitations": [ InvitationObject, ... ] }`
@@ -75,6 +80,11 @@ curl "https://data.spuree.com/api/v1/projects/invitations/pending" \
 ---
 
 ### POST /v1/projects/invitations/{token}/accept
+
+<!-- spuree-agent
+surfaces: ["local", "desktop", "backend", "hosted-web"]
+webSafe: true
+-->
 
 Accept an invitation. The user is added to the project's `sharedWith` list and automatically joined to the workspace if not already a member.
 
@@ -104,6 +114,11 @@ curl -X POST "https://data.spuree.com/api/v1/projects/invitations/{token}/accept
 
 ### POST /v1/projects/invitations/{token}/decline
 
+<!-- spuree-agent
+surfaces: ["local", "desktop", "backend", "hosted-web"]
+webSafe: true
+-->
+
 Decline an invitation.
 
 **Response:** `{ "messageCode": "success", "projectId": "..." }`
@@ -116,6 +131,11 @@ curl -X POST "https://data.spuree.com/api/v1/projects/invitations/{token}/declin
 ---
 
 ### GET /v1/projects/{projectId}/invitations
+
+<!-- spuree-agent
+surfaces: ["local", "desktop", "backend", "hosted-web"]
+webSafe: true
+-->
 
 List all invitations for a project (all statuses).
 
@@ -132,6 +152,11 @@ curl "https://data.spuree.com/api/v1/projects/{projectId}/invitations" \
 
 ### DELETE /v1/projects/{projectId}/invitations/{invitationId}
 
+<!-- spuree-agent
+surfaces: ["local", "desktop", "backend", "hosted-web"]
+webSafe: true
+-->
+
 Cancel a pending invitation.
 
 **Authorization:** Project owner or original inviter.
@@ -146,6 +171,11 @@ curl -X DELETE "https://data.spuree.com/api/v1/projects/{projectId}/invitations/
 ---
 
 ### POST /v1/projects/{projectId}/invitations/{invitationId}/resend
+
+<!-- spuree-agent
+surfaces: ["local", "desktop", "backend", "hosted-web"]
+webSafe: true
+-->
 
 Resend an invitation — resets expiry to 7 days from now.
 

--- a/project-management/SKILL.md
+++ b/project-management/SKILL.md
@@ -49,6 +49,11 @@ Project
 
 ### GET /v1/projects
 
+<!-- spuree-agent
+surfaces: ["local", "desktop", "backend", "hosted-web"]
+webSafe: true
+-->
+
 List projects accessible to the authenticated user, with workspace/organization lookup tables.
 
 **Query Parameters:**
@@ -90,6 +95,11 @@ curl "https://data.spuree.com/api/v1/projects" \
 
 ### POST /v1/projects
 
+<!-- spuree-agent
+surfaces: ["local", "desktop", "backend", "hosted-web"]
+webSafe: true
+-->
+
 Create a new project. Name must be Windows filesystem-compatible.
 
 **Where to get `workspaceId`:** From auth response `user.workspaces[].workspaceId` or from `GET /v1/projects`.
@@ -120,6 +130,11 @@ curl -X POST "https://data.spuree.com/api/v1/projects" \
 
 ### PATCH /v1/projects/{projectId}
 
+<!-- spuree-agent
+surfaces: ["local", "desktop", "backend", "hosted-web"]
+webSafe: true
+-->
+
 Rename a project.
 
 | Field | Type | Required | Description |
@@ -139,6 +154,11 @@ curl -X PATCH "https://data.spuree.com/api/v1/projects/{projectId}" \
 
 ### DELETE /v1/projects/{projectId}
 
+<!-- spuree-agent
+surfaces: ["local", "desktop", "backend", "hosted-web"]
+webSafe: true
+-->
+
 Soft-delete a project.
 
 **Response:** `{ messageCode, message, projectId }`
@@ -151,6 +171,11 @@ curl -X DELETE "https://data.spuree.com/api/v1/projects/{projectId}" \
 ---
 
 ### GET /v1/projects/{projectId}/children
+
+<!-- spuree-agent
+surfaces: ["local", "desktop", "backend", "hosted-web"]
+webSafe: true
+-->
 
 Browse a project's immediate contents: folders, entities (assets), and files. Use **folder-management** skill's `GET /v1/sessions/{folderId}/children` to navigate deeper.
 
@@ -173,6 +198,11 @@ curl "https://data.spuree.com/api/v1/projects/{projectId}/children" \
 ---
 
 ### POST /v1/projects/{projectId}/share
+
+<!-- spuree-agent
+surfaces: ["local", "desktop", "backend", "hosted-web"]
+webSafe: true
+-->
 
 Share a project with another user. Behaves differently based on target's workspace membership:
 
@@ -202,6 +232,11 @@ curl -X POST "https://data.spuree.com/api/v1/projects/{projectId}/share" \
 
 ### DELETE /v1/projects/{projectId}/share/{email}
 
+<!-- spuree-agent
+surfaces: ["local", "desktop", "backend", "hosted-web"]
+webSafe: true
+-->
+
 Remove a user from a shared project. **Owner only.**
 
 **Response:** `{ messageCode, message, projectId }`
@@ -215,6 +250,11 @@ curl -X DELETE "https://data.spuree.com/api/v1/projects/{projectId}/share/{email
 
 ### GET /v1/projects/{projectId}/share
 
+<!-- spuree-agent
+surfaces: ["local", "desktop", "backend", "hosted-web"]
+webSafe: true
+-->
+
 List the project's sharing info. **Owner or shared user.**
 
 **Response:** `{ owner: "owner@example.com", sharedWith: ["..."] }`
@@ -227,6 +267,11 @@ curl "https://data.spuree.com/api/v1/projects/{projectId}/share" \
 ---
 
 ### POST /v1/projects/{projectId}/leave
+
+<!-- spuree-agent
+surfaces: ["local", "desktop", "backend", "hosted-web"]
+webSafe: true
+-->
 
 Leave a project shared with you. **Owner cannot leave.**
 


### PR DESCRIPTION
## Summary

Tracks Linear issue: [ENG-5169](https://linear.app/cheehoo-labs-inc/issue/ENG-5169/document-hosted-web-agent-surfaces-for-spuree-skills)

This update documents agent exposure metadata for SpureeSkills endpoints and clarifies which APIs are safe for hosted-web MCP clients.

## Changes

- Add README guidance for hidden `spuree-agent` metadata, supported surfaces, and `webSafe` usage.
- Add hosted-web safety metadata across project, folder, invitation, sharing, and search/read endpoints.
- Keep auth, API-key management, direct upload, multipart upload, and presigned bulk download flows off hosted-web surfaces.
- Document `GET /v1/files/{fileId}/content` for inline small text-file retrieval by agents.

## Validation

- `git diff --cached --check`
- No executable test suite found in this docs-only repository.
