### PR TITLE
docs(children): document unified items[] shape for project/folder browsing (ENG-5223)

### DIFF
--- a/folder-management/SKILL.md
+++ b/folder-management/SKILL.md
@@ -251,25 +251,27 @@ Browse a folder's immediate contents.
 
 | Parameter | Type | Default | Description |
 | --- | --- | --- | --- |
-| `limit` | integer | 100 | Results per page (max: 500) |
-| `offset` | integer | 0 | Number of items to skip |
+| `sortBy` | string | `lastModified` | Sort key: `lastModified` \| `createdDate` \| `name` |
+| `sortOrder` | string | `desc` | Sort direction: `asc` \| `desc` |
+| `limit` | integer | 100 | Items in the unified list (max: 500) |
+| `offset` | integer | 0 | Number of items to skip in the unified list |
 
-**Response:**
+**Response:** `{ items: [...] }` — one flat array mixing sub-folders, entities, and files, sorted by the chosen key. Each item carries a `type` discriminator (`"session"`, `"entity"`, or `"file"`) that selects its fields. An empty folder returns `{ "items": [] }`.
 
 ```json
 {
-  "sessions": [
+  "items": [
     {
+      "type": "session",
       "id": "64a7b8c9d1e2f3a4b5c6d7e8",
       "name": "Sub-folder",
       "sessionType": "session",
       "status": "active",
       "createdAt": "2024-01-15T10:00:00Z",
       "updatedAt": "2024-01-15T10:00:00Z"
-    }
-  ],
-  "entities": [
+    },
     {
+      "type": "entity",
       "id": "64a7b8c9d1e2f3a4b5c6d7e9",
       "name": "Hero Character",
       "entityType": "character",
@@ -284,13 +286,13 @@ Browse a folder's immediate contents.
         "key": "previews/hero_high.jpg",
         "fileFormat": "jpg"
       }
-    }
-  ],
-  "files": [
+    },
     {
+      "type": "file",
       "id": "64a7b8c9d1e2f3a4b5c6d7ea",
-      "fileName": "reference_sheet",
+      "name": "reference_sheet",
       "fileFormat": "png",
+      "fileSize": 20480,
       "key": "works_abc/sess_def/file_ghi",
       "sourceCharacter": null,
       "presignedUrl": "https://s3.amazonaws.com/...",
@@ -300,15 +302,17 @@ Browse a folder's immediate contents.
 }
 ```
 
-**Children Types:**
+> **Parsing note:** Read the `items` array. **Do not** look for separate top-level `sessions`, `entities`, or `files` arrays — older deployments returned that shape, but the current API returns the unified `items` list, so a parser expecting the old shape sees an empty result and wrongly concludes the folder is empty. For backward compatibility, a robust parser can read `items` first and fall back to the legacy `sessions`/`entities`/`files` arrays only when `items` is absent.
 
-| Array | Contains | Description |
+**Item Types** (selected by `type`):
+
+| `type` | Contains | Description |
 | --- | --- | --- |
-| `sessions` | Folders | Sub-folders — navigate deeper with this same endpoint |
-| `entities` | Assets | Entity sessions with preview images |
-| `files` | Files | Files with presigned download URLs |
+| `session` | Folder | Sub-folder — navigate deeper with this same endpoint |
+| `entity` | Asset | Entity session with preview images |
+| `file` | File | File with a presigned download URL |
 
-**Entity Fields:**
+**Entity Item Fields** (`type: "entity"`):
 
 | Field | Type | Description |
 | --- | --- | --- |
@@ -319,13 +323,14 @@ Browse a folder's immediate contents.
 | `entityPreview` | object? | Low-res preview (`presignedUrl`, `key`, `fileFormat`) |
 | `highResEntityPreview` | object? | High-res preview |
 
-**File Fields:**
+**File Item Fields** (`type: "file"`):
 
 | Field | Type | Description |
 | --- | --- | --- |
 | `id` | string | File ObjectId |
-| `fileName` | string | File name (without extension) |
+| `name` | string | File name (without extension; mirrors the file's `fileName`) |
 | `fileFormat` | string | File extension (lowercase) |
+| `fileSize` | integer? | File size in bytes |
 | `key` | string | S3 object key |
 | `sourceCharacter` | string? | Associated character name |
 | `presignedUrl` | string | S3 presigned download URL |
@@ -559,13 +564,13 @@ curl -X POST "https://data.spuree.com/api/v1/sessions/files/download/urls" \
 1. **Get project children** (via **project-management** skill):
 
    ```
-   GET /v1/projects/{projectId}/children → { sessions, entities, files }
+   GET /v1/projects/{projectId}/children → { items: [...] }
    ```
 
 2. **Navigate into a folder:**
 
    ```
-   GET /v1/sessions/{folderId}/children → { sessions, entities, files }
+   GET /v1/sessions/{folderId}/children → { items: [...] }
    ```
 
 3. **Repeat** to go deeper into sub-folders.

--- a/project-management/SKILL.md
+++ b/project-management/SKILL.md
@@ -152,18 +152,53 @@ curl -X DELETE "https://data.spuree.com/api/v1/projects/{projectId}" \
 
 ### GET /v1/projects/{projectId}/children
 
-Browse a project's immediate contents: folders, entities (assets), and files. Use **folder-management** skill's `GET /v1/sessions/{folderId}/children` to navigate deeper.
+Browse a project's immediate contents — folders, entities (assets), and files — as a **single unified `items` list** sorted by the chosen key. Use **folder-management** skill's `GET /v1/sessions/{folderId}/children` to navigate deeper.
 
 | Parameter | Type | Default | Description |
 | --- | --- | --- | --- |
-| `limit` | integer | 100 | Results per category (max 500) |
-| `offset` | integer | 0 | Items to skip |
+| `sortBy` | string | `lastModified` | Sort key: `lastModified` \| `createdDate` \| `name` |
+| `sortOrder` | string | `desc` | Sort direction: `asc` \| `desc` |
+| `limit` | integer | 100 | Items in the unified list (max 500) |
+| `offset` | integer | 0 | Items to skip in the unified list |
 
-**Response:** `{ sessions: [...], entities: [...], files: [...] }`
+**Response:** `{ items: [...] }` — one flat array mixing folders, entities, and files. Each item carries a `type` discriminator (`"session"`, `"entity"`, or `"file"`) that selects its fields. An empty project returns `{ "items": [] }`.
 
-- `sessions` — folders (`sessionType: "session"`)
-- `entities` — assets with preview images (character, motion, prop, etc.)
-- `files` — files with presigned download URLs
+```json
+{
+  "items": [
+    {
+      "type": "file",
+      "id": "64a7b8c9d1e2f3a4b5c6d7ea",
+      "name": "GUIDE",
+      "fileFormat": "md",
+      "fileSize": 1024,
+      "key": "works_abc/sess_def/file_ghi",
+      "presignedUrl": "https://s3.amazonaws.com/..."
+    },
+    {
+      "type": "session",
+      "id": "64a7b8c9d1e2f3a4b5c6d7e8",
+      "name": "storyboard",
+      "sessionType": "session"
+    },
+    {
+      "type": "entity",
+      "id": "64a7b8c9d1e2f3a4b5c6d7e9",
+      "name": "Hero Character",
+      "entityType": "character",
+      "entityPreview": { "presignedUrl": "https://s3.amazonaws.com/...", "key": "...", "fileFormat": "jpg" }
+    }
+  ]
+}
+```
+
+| `type` | Meaning | Key fields |
+| --- | --- | --- |
+| `session` | Folder | `sessionType` (`"session"`), `parentSessions` — navigate deeper via folder-management |
+| `entity` | Asset | `entityType` (character, motion, prop, etc.), `entityPreview` (preview image) |
+| `file` | File | `name` (mirrors the file's `fileName`), `fileFormat`, `fileSize`, `key`, `presignedUrl` (download URL) |
+
+> **Parsing note:** Read the `items` array. **Do not** look for separate top-level `sessions`, `entities`, or `files` arrays — older deployments returned that shape, but the current API returns the unified `items` list, so a parser expecting the old shape sees an empty result and wrongly concludes the project is empty. For backward compatibility, a robust parser can read `items` first and fall back to the legacy `sessions`/`entities`/`files` arrays only when `items` is absent.
 
 ```bash
 curl "https://data.spuree.com/api/v1/projects/{projectId}/children" \


### PR DESCRIPTION
## Summary

`GET /v1/projects/{id}/children` and `GET /v1/sessions/{id}/children` return a single unified `items` array — each entry tagged with a `type` discriminator (`session` / `entity` / `file`) — but the **project-management** and **folder-management** skill docs still described the old separate `sessions` / `entities` / `files` arrays. An agent following the stale docs reads those missing arrays, sees nothing, and wrongly reports the project/folder as **empty** (exactly the ENG-5223 repro on the `SpureeSkill_SeedanceTutorial` project, which has one top-level file and five folders).

The backend has returned the unified `items` shape on `main` since the children-unification change landed (2026-04-29), so both dev and prod serve `items[]`; only the docs were stale.

## Changes

Both `project-management/SKILL.md` and `folder-management/SKILL.md` children sections:

- Rewrite the response to the `items[]` shape, with a worked example containing **a file and a session** (plus an entity)
- Document the per-`type` fields (session / entity / file)
- Document the new `sortBy` / `sortOrder` query params and correct `limit` semantics (now caps the unified list, not per-category)
- Update the file item field from `fileName` → `name` (which mirrors the file's `fileName`)
- Add a **parsing note**: read `items` first; fall back to the legacy `sessions`/`entities`/`files` arrays only when `items` is absent (backward compatibility for older deployments)

`/assets` and `/files` endpoints (which legitimately return a `files` array) are left unchanged.

## Notes

- The backend already has regression coverage for the `items[]` shape with mixed file + session + entity rows (`test_project_service.py`: `test_get_project_children_success`, `test_get_session_children_success`, `test_build_children_response`).
- The same doc fix is applied to the internal skills repo (InternalSpureeSkills PR #57).

Closes ENG-5223.

🤖 Generated with [Claude Code](https://claude.com/claude-code)