### PR TITLE
docs(skills): sharpen 7 retrieval endpoint descriptions + add files/{id}/content (ENG-5383)

### DIFF
--- a/file-management/SKILL.md
+++ b/file-management/SKILL.md
@@ -134,6 +134,32 @@ curl "https://data.spuree.com/api/v1/files/{fileId}" \
 
 ---
 
+### GET /v1/files/{fileId}/content
+
+<!-- spuree-agent
+surfaces: ["local", "desktop", "backend", "hosted-web"]
+webSafe: true
+-->
+
+Fetch the raw text content of a file (markdown, JSON, CSV, YAML, XML, logs) inline. Use this to read a file's content directly without following a presigned download URL.
+
+This endpoint is not a replacement for file downloads. Binary files and large files should still use `GET /v1/files/{fileId}` and its `downloadUrl`.
+
+**Response:** `{ "data": { id, fileName, fileFormat, mimeType, size, encoding, content, truncated } }`
+
+| Code | Description |
+| --- | --- |
+| 200 | Text content returned |
+| 413 | File is too large to return inline |
+| 415 | Unsupported/binary format or invalid UTF-8 |
+
+```bash
+curl "https://data.spuree.com/api/v1/files/{fileId}/content" \
+  -H "Authorization: Bearer $SPUREE_ACCESS_TOKEN"
+```
+
+---
+
 ### POST /v1/files
 
 Create a file record and get presigned upload URL(s). Automatically selects upload mode based on file size:

--- a/file-management/SKILL.md
+++ b/file-management/SKILL.md
@@ -141,11 +141,13 @@ surfaces: ["local", "desktop", "backend", "hosted-web"]
 webSafe: true
 -->
 
-Fetch the raw text content of a file (markdown, JSON, CSV, YAML, XML, logs) inline. Use this to read a file's content directly without following a presigned download URL.
+Get inline UTF-8 text content for a small text-like file. Use this when an agent needs to read markdown, text, JSON, CSV, YAML, XML, subtitles, logs, or source files directly instead of following a short-lived CloudFront download URL.
 
 This endpoint is not a replacement for file downloads. Binary files and large files should still use `GET /v1/files/{fileId}` and its `downloadUrl`.
 
 **Response:** `{ "data": { id, fileName, fileFormat, mimeType, size, encoding, content, truncated } }`
+
+`truncated` is reserved: oversize files return `413` rather than a partial body, so it is currently always `false`.
 
 | Code | Description |
 | --- | --- |

--- a/folder-management/SKILL.md
+++ b/folder-management/SKILL.md
@@ -237,7 +237,7 @@ curl -X DELETE "https://data.spuree.com/api/v1/sessions/64a7b8c9d1e2f3a4b5c6d7e8
 
 ### GET /v1/sessions/{sessionId}/children
 
-Browse a folder's immediate contents.
+List a folder's immediate contents — sub-folders, asset entities, and files. Use this to browse into a folder when you have its ID and want to see everything inside.
 
 **Description:** Returns the direct children of a folder: sub-folders, entities (assets), and files. Same response format as `GET /v1/projects/{projectId}/children`.
 
@@ -358,7 +358,7 @@ curl "https://data.spuree.com/api/v1/sessions/64a7b8c9d1e2f3a4b5c6d7e8/children?
 
 ### GET /v1/sessions/{sessionId}/assets
 
-Get assets (entities) in a folder.
+List the published asset entities (character, motion, prop, etc.) in a folder with their preview images. Use this when you need assets only, not raw files or sub-folders.
 
 **Description:** Returns entity sessions and their associated files for a given folder.
 
@@ -426,7 +426,7 @@ curl "https://data.spuree.com/api/v1/sessions/64a7b8c9d1e2f3a4b5c6d7e8/assets" \
 
 ### GET /v1/sessions/{sessionId}/files
 
-Get files in a folder.
+List the files directly in a folder (optionally flattened to include sub-folder files). Use this when you need file records for a known folder without browsing sub-folders.
 
 **Description:** Returns files associated with a folder. By default, flattens results to include files from sub-folders via entity session linkage.
 

--- a/project-management/SKILL.md
+++ b/project-management/SKILL.md
@@ -49,7 +49,7 @@ Project
 
 ### GET /v1/projects
 
-List projects accessible to the authenticated user, with workspace/organization lookup tables.
+List all projects accessible to the authenticated user. Use this to discover project IDs and their workspace context before browsing project contents.
 
 **Query Parameters:**
 
@@ -152,7 +152,7 @@ curl -X DELETE "https://data.spuree.com/api/v1/projects/{projectId}" \
 
 ### GET /v1/projects/{projectId}/children
 
-Browse a project's immediate contents — folders, entities (assets), and files — as a **single unified `items` list** sorted by the chosen key. Use **folder-management** skill's `GET /v1/sessions/{folderId}/children` to navigate deeper.
+List a project's immediate contents — folders, asset entities, and files — as a **single unified `items` list**. Use this after `GET /v1/projects` to start browsing a project's top-level structure; use **folder-management** skill's `GET /v1/sessions/{folderId}/children` to navigate deeper.
 
 | Parameter | Type | Default | Description |
 | --- | --- | --- | --- |


### PR DESCRIPTION
## What

Docs-only. Sharpens the descriptions of the retrieval/read endpoints to be more action-oriented (verb-first, "use this when…"), and documents the inline file-content endpoint.

### Changes
- Sharpen descriptions for: `GET /v1/search`, `GET /v1/sessions/{id}/children`, `GET /v1/sessions/{id}/assets`, `GET /v1/sessions/{id}/files`, `GET /v1/projects`, `GET /v1/projects/{projectId}/children`.
- Add `GET /v1/files/{fileId}/content` — inline UTF-8 text retrieval (binary/oversize fall back to metadata).

### Merge notes
- The `GET /v1/files/{fileId}/content` block overlaps **PR #1** — keep a single copy at merge.
- The `GET /v1/projects/{projectId}/children` description line also changes in **PR #2** — reconcile that one line at merge.