### PR TITLE
docs: /v1/search — no semantic param (lexical only), GET-only (POST → 405)

### DIFF
--- a/file-management/SKILL.md
+++ b/file-management/SKILL.md
@@ -60,6 +60,10 @@ Full-text search across files, folders, projects, and assets. Backed by the `con
 | `cursor` | string | — | Opaque pagination token from a previous response. Pass to fetch the next page. |
 | `includePreview` | boolean | `false` | When `true`, **`asset`** results add a short-lived signed `previewUrl` (~1h) and `previewFileFormat` for the cover image/video. Other source types are unaffected; the raw bucket/key pointer is never returned. |
 
+> **No semantic search (yet).** There is no `semantic` parameter. Matching is lexical full-text (Atlas analyzer-based token matching) — unrecognized query params such as `semantic=true` are silently ignored, so the request succeeds but results are still lexical matches. Semantic/embedding retrieval is on the roadmap.
+
+> **GET only.** `POST /v1/search` is not supported and returns `405 Method Not Allowed`. All search options are query parameters on `GET`.
+
 **Response:** `{ "data": [...], "count": N, "cursor": "<opaque token or null>" }`
 
 Each `data` item is one matched source object. Common fields:


### PR DESCRIPTION
## What

Two small additions to the `GET /v1/search` docs in `file-management/SKILL.md`:

1. **No semantic search (yet)** — there is no `semantic` parameter; unrecognized query params (e.g. `semantic=true`) are silently ignored and results remain lexical full-text. Semantic retrieval is on the roadmap.
2. **GET only** — `POST /v1/search` returns `405 Method Not Allowed`.

## Why

PLOCAN's agent (Alba) explicitly tested both `semantic=true` and `POST /v1/search` during their May API evaluation and will re-run the same matrix when re-testing the new content search. Documenting these two behaviors up front prevents an agent from misreading silent param acceptance as a live feature, and keeps the public skills ahead of their test instead of behind it.

Verified against production today: `semantic=true` returns the same lexical results as without it; `POST /v1/search` → 405.

🤖 Generated with [Claude Code](https://claude.com/claude-code)