### PR TITLE
docs(skills): canonicalize bounded folder discovery

### DIFF
--- a/.github/workflows/pr-tests.yml
+++ b/.github/workflows/pr-tests.yml
@@ -12,8 +12,8 @@ jobs:
   skill-contracts:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
-      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version: 22.23.2
       - name: Test scripts

--- a/.github/workflows/pr-tests.yml
+++ b/.github/workflows/pr-tests.yml
@@ -1,0 +1,22 @@
+name: PR Tests
+
+on:
+  pull_request:
+  push:
+    branches: [main]
+
+permissions:
+  contents: read
+
+jobs:
+  skill-contracts:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
+        with:
+          node-version: 22.23.2
+      - name: Test scripts
+        run: node --test test/*.test.mjs
+      - name: Check folder-discovery contract
+        run: node scripts/check-folder-discovery-contract.mjs

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ Connect Claude Code, Claude Code Web & Cowork, ChatGPT, Codex, or OpenClaw — v
 | [Getting Started](./getting-started/SKILL.md) | Learn what Spuree can do and complete a safe guided first run |
 | [Authentication](./authentication/SKILL.md) | Obtain JWT tokens, manage API keys |
 | [Project Management](./project-management/SKILL.md) | Create, list, update, delete, and share projects; browse contents |
-| [Folder Management](./folder-management/SKILL.md) | List recent folders across projects; create, update, delete, browse, and download folder content |
+| [Folder Management](./folder-management/SKILL.md) | Find canonical folders in one bounded call, list recent folders, and create, update, delete, browse, or download folder content |
 | [File Management](./file-management/SKILL.md) | Get, create, upload, update, and delete files with checksum-verified uploads (includes name search) |
 | [File Comments](./file-comment/SKILL.md) | Add, list, resolve, update, and delete line-anchored review comments on files, with threaded replies and @mentions |
 | [Project Invitations](./project-invitation/SKILL.md) | Manage sharing invitations for non-workspace members |
@@ -51,3 +51,28 @@ All skills use the V1 API. Two authentication methods are supported:
 | API key | `X-API-Key: <key>` | Automation and long-lived access |
 
 See the [Authentication skill](./authentication/SKILL.md) for details on obtaining tokens and managing API keys.
+
+## Contract checks and diagnostics
+
+The folder-discovery contract is checked offline so documentation drift fails
+before release. The guard pins exact endpoint headings, ordered query
+parameters (types, required flags, defaults, enums, and bounds), canonical
+context object shapes, response field names and types, closed response enums,
+status codes, and bounded fallback behavior:
+
+```bash
+node scripts/check-folder-discovery-contract.mjs
+node --test test/*.test.mjs
+```
+
+To diagnose duplicate public and plugin skill copies without changing or
+deleting any installation, run:
+
+```bash
+node scripts/diagnose-spuree-skill-copies.mjs
+node scripts/diagnose-spuree-skill-copies.mjs --json
+```
+
+The diagnostic reports paths, SHA-256 hashes, catalog scan order, and plugin
+namespace/version metadata. Scan order is informational; the active client owns
+runtime precedence when duplicate unprefixed skill names exist.

--- a/README.md
+++ b/README.md
@@ -82,5 +82,8 @@ OpenClaw workspace/global, Hermes global, and Codex plugin-cache roots. It
 reports paths, SHA-256 hashes, catalog scan order, exposed names, and plugin
 namespace/version metadata. Collision groups use the exposed skill name, so a
 namespaced plugin such as `internal-spuree-skills:folder-management` is not
-misreported as shadowing the public `folder-management` skill. Scan order is
-informational; the active client owns runtime precedence.
+misreported as shadowing the public `folder-management` skill. If a cached
+plugin manifest is missing or unreadable, the diagnostic assigns that cache
+root a stable `unknown-plugin-<hash>` namespace instead of assuming the skill
+is bare. Scan order is informational; the active client owns runtime
+precedence.

--- a/README.md
+++ b/README.md
@@ -66,13 +66,21 @@ node --test test/*.test.mjs
 ```
 
 To diagnose duplicate public and plugin skill copies without changing or
-deleting any installation, run:
+deleting any installation, run the script from a checkout of this repository
+and point `--target` at the project or agent workspace whose active catalog you
+want to inspect:
 
 ```bash
-node scripts/diagnose-spuree-skill-copies.mjs
-node scripts/diagnose-spuree-skill-copies.mjs --json
+node scripts/diagnose-spuree-skill-copies.mjs --target /path/to/project
+node scripts/diagnose-spuree-skill-copies.mjs --target /path/to/project --json
 ```
 
-The diagnostic reports paths, SHA-256 hashes, catalog scan order, and plugin
-namespace/version metadata. Scan order is informational; the active client owns
-runtime precedence when duplicate unprefixed skill names exist.
+When the checkout and target project differ, the checkout remains the immutable
+source reference while `--target` controls project/workspace discovery. The
+diagnostic scans all seven public skills across `.agents`, `.codex`, `.claude`,
+OpenClaw workspace/global, Hermes global, and Codex plugin-cache roots. It
+reports paths, SHA-256 hashes, catalog scan order, exposed names, and plugin
+namespace/version metadata. Collision groups use the exposed skill name, so a
+namespaced plugin such as `internal-spuree-skills:folder-management` is not
+misreported as shadowing the public `folder-management` skill. Scan order is
+informational; the active client owns runtime precedence.

--- a/file-comment/SKILL.md
+++ b/file-comment/SKILL.md
@@ -366,7 +366,7 @@ Only users with access to the file can be mentioned; tokens for other users are 
 
 1. Read the file content (**file-management** skill: `GET /v1/files/{fileId}/content`).
 2. Leave comments on the lines that need work: `POST /v1/files/{fileId}/comments` with `startLine`/`endLine`/`sourceText`.
-3. Share the file link so the author sees the feedback in Studio: `https://studio.spuree.com/file/{fileId}`.
+3. Share the file link so the author sees the feedback in Studio: `https://studio.spuree.com/files/{fileId}`.
 
 ### Resolve Feedback After a Revision
 

--- a/file-management/SKILL.md
+++ b/file-management/SKILL.md
@@ -57,7 +57,7 @@ and uses an opaque cursor for pagination.
 | `createdAfter` | string | No | — | ISO 8601 lower bound on source `createdAt`. **Timezone required** (`Z` or `±HH:MM`) — naive datetimes → 422. |
 | `createdBefore` | string | No | — | ISO 8601 upper bound. Timezone required. |
 | `limit` | integer | No | 50 | Page size (1–200). |
-| `cursor` | string | No | — | Opaque pagination token from a previous response. Replay the original `q` and every corpus-shaping filter. Newly issued cursors bind that corpus; pre-`matchMode` legacy cursors remain accepted as unbound `any`-mode compatibility tokens and must never be reused with another corpus. |
+| `cursor` | string | No | — | Opaque pagination token from a previous response. Replay the original `q` and every corpus-shaping filter. Newly issued cursors use HMAC-signed `v1` envelopes and bind that corpus. Unsigned pre-v1 cursors remain accepted as unbound `any`-mode compatibility tokens only until 2026-09-07 00:00 UTC and must never be reused with another corpus. |
 | `sortBy` | string | No | `relevance` | Result ordering: `relevance` \| `createdAt`. |
 | `sortOrder` | string | No | `desc` | Direction for `sortBy=createdAt`: `asc` \| `desc`. Ignored for relevance, which is always descending. |
 | `includePreview` | boolean | No | `false` | When `true`, **`asset`** results add a short-lived signed `previewUrl` (~1h) and `previewFileFormat` for the cover image/video. Other source types are unaffected; the raw bucket/key pointer is never returned. |
@@ -145,13 +145,18 @@ curl "https://data.spuree.com/api/v1/search?q=hero&type=file&cursor=<token>" \
   -H "Authorization: Bearer $SPUREE_ACCESS_TOKEN"
 ```
 
-Newly issued cursors also bind the caller's current permission scope. Treat a
-cursor as opaque; do not edit or reuse it with a different query, source type,
-filter set, or caller. A malformed or mismatched bound cursor returns 422.
-Pre-`matchMode` legacy cursors are treated as unbound `any`-mode compatibility
-tokens, regardless of a re-sent `matchMode`, so keep one only within its
-original pagination sequence. Newly issued cursors remain bound and reject a
-mismatched corpus.
+Newly issued HMAC-signed `v1` cursors also bind the caller's current permission
+scope. Treat a cursor as opaque; do not edit or reuse it with a different query,
+source type, filter set, or caller. A malformed, tampered, or mismatched bound
+cursor returns 422.
+
+Unsigned pre-v1 cursors are treated as unbound `any`-mode compatibility tokens,
+regardless of a re-sent `matchMode`, only until **2026-09-07 00:00 UTC**. During
+that bounded migration window, a fully stripped and re-encoded modern payload
+is statelessly indistinguishable from a genuine v0 token, so keep any unsigned
+cursor only within its original pagination sequence. At and after the sunset,
+every unsigned cursor is rejected; only a valid signed `v1` envelope is
+accepted.
 
 **Status Codes:**
 
@@ -161,7 +166,7 @@ mismatched corpus.
 | 400 | `search_query_too_broad`: query would match at least the bounded threshold; refine the terms. |
 | 401 | Invalid or expired credential. |
 | 403 | OAuth credential lacks the `read` scope. |
-| 422 | Missing/invalid parameter, timezone-less date, malformed narrowing ID, or malformed/mismatched cursor. |
+| 422 | Missing/invalid parameter, timezone-less date, malformed narrowing ID, malformed/tampered/mismatched cursor, or an unsigned cursor at/after the migration sunset. |
 | 500 | Non-transient search or canonical-storage failure. |
 | 503 | `search_context_unavailable`: canonical validation could not safely advance a stale-only page. |
 

--- a/file-management/SKILL.md
+++ b/file-management/SKILL.md
@@ -38,27 +38,29 @@ Or: `X-API-Key: $SPUREE_API_KEY`. See the **authentication** skill.
 
 Full-text search across files, folders, projects, and assets. Backed by the `content_index` collection (Atlas `$search`), kept in sync via MongoDB Change Streams.
 
-> **⚠️ Breaking change (ENG-5362).** This endpoint replaced the legacy `sessions`/`files` regex search. Both the request params and the response shape changed:
-> - Matching is now Atlas **analyzer-based token matching**, not case-insensitive regex substring. `upload` no longer substring-matches `spuree_upload_test.txt`.
-> - `type` values changed: old `file` | `session` → new `file` | `folder` | `project` | `asset` (the old `session` split into `folder`/`project`, plus a new `asset` source type).
-> - Response is now **grouped** — one item per source object with a `matches[]` array — and paginated by an opaque `cursor` instead of a flat list with `limit`/offset.
+Search is Atlas analyzer-based rather than substring matching. It returns one
+grouped item per source object, with the matching indexed rows in `matches[]`,
+and uses an opaque cursor for pagination.
 
 **Query Parameters:**
 
-| Parameter | Type | Default | Description |
-| --- | --- | --- | --- |
-| `q` | string | — | Search query (**required**, 1–255 chars). Full-text token match. |
-| `type` | string | — | Filter by source type: `file` \| `folder` \| `project` \| `asset`. Omit for all. |
-| `searchIn` | string | `all` | Which rows to search: `name` \| `content` (body + annotation) \| `all`. |
-| `format` | string | — | Comma-separated file formats, e.g. `txt,md`. Applies to `file` type only. |
-| `entityType` | string | — | Comma-separated entity types, e.g. `character,prop`. Applies to `asset` type only. |
-| `workspaceId` | string | — | Restrict to a single workspace (ObjectId). Must be one the caller is a member of, else empty page; malformed id → 422. |
-| `projectId` | string | — | Restrict to a single project (ObjectId). Must be one the caller can access, else empty page; malformed id → 422. |
-| `createdAfter` | string | — | ISO 8601 lower bound on source `createdAt`. **Timezone required** (`Z` or `±HH:MM`) — naive datetimes → 422. |
-| `createdBefore` | string | — | ISO 8601 upper bound. Timezone required. |
-| `limit` | integer | 50 | Page size (1–200). |
-| `cursor` | string | — | Opaque pagination token from a previous response. Pass to fetch the next page. |
-| `includePreview` | boolean | `false` | When `true`, **`asset`** results add a short-lived signed `previewUrl` (~1h) and `previewFileFormat` for the cover image/video. Other source types are unaffected; the raw bucket/key pointer is never returned. |
+| Parameter | Type | Required | Default | Description |
+| --- | --- | --- | --- | --- |
+| `q` | string | Yes | — | Search query (1–255 chars). Full-text token match. |
+| `type` | string | No | — | Filter by source type: `file` \| `folder` \| `project` \| `asset`. Deprecated `workspace` remains accepted for compatibility and returns an empty page because workspace rows are not indexed. Omit for all. |
+| `searchIn` | string | No | `all` | Indexed rows to search: `name` \| `content` (body + annotation) \| `all`. |
+| `matchMode` | string | No | `any` | Term matching inside each indexed row: `any` \| `all` \| `phrase`. `any` matches at least one analyzed term, `all` requires every analyzed term, and `phrase` requires ordered adjacent terms. |
+| `format` | string | No | — | Comma-separated file formats, e.g. `txt,md`. Applies to `file` type only. |
+| `entityType` | string | No | — | Comma-separated entity types, e.g. `character,prop`. Applies to `asset` type only. |
+| `workspaceId` | string | No | — | Restrict to a single workspace (ObjectId). Must be one the caller is a member of, else empty page; malformed id → 422. |
+| `projectId` | string | No | — | Restrict to a single project (ObjectId). Must be one the caller can access, else empty page; malformed id → 422. |
+| `createdAfter` | string | No | — | ISO 8601 lower bound on source `createdAt`. **Timezone required** (`Z` or `±HH:MM`) — naive datetimes → 422. |
+| `createdBefore` | string | No | — | ISO 8601 upper bound. Timezone required. |
+| `limit` | integer | No | 50 | Page size (1–200). |
+| `cursor` | string | No | — | Opaque pagination token from a previous response. Replay the original `q` and every corpus-shaping filter. Newly issued cursors bind that corpus; pre-`matchMode` legacy cursors remain accepted as unbound `any`-mode compatibility tokens and must never be reused with another corpus. |
+| `sortBy` | string | No | `relevance` | Result ordering: `relevance` \| `createdAt`. |
+| `sortOrder` | string | No | `desc` | Direction for `sortBy=createdAt`: `asc` \| `desc`. Ignored for relevance, which is always descending. |
+| `includePreview` | boolean | No | `false` | When `true`, **`asset`** results add a short-lived signed `previewUrl` (~1h) and `previewFileFormat` for the cover image/video. Other source types are unaffected; the raw bucket/key pointer is never returned. |
 
 **Response:** `{ "data": [...], "count": N, "cursor": "<opaque token or null>" }`
 
@@ -73,9 +75,40 @@ Each `data` item is one matched source object. Common fields:
 | `matches` | array | Per-row matches (see below) |
 | `workspaceId` | string? | Workspace ObjectId |
 | `projectId` | string? | Project ObjectId |
-| `sourceCreatedAt` | datetime | Source object's creation timestamp |
+| `sourceCreatedAt` | datetime \| null | Source object's creation timestamp when indexed. |
+| `container` | object \| null | Canonical object with `id`, `name`, and `kind`; `kind` is `folder` or `project`. File: immediate owner. Folder: immediate parent. |
+| `project` | object \| null | Canonical creative-project owner (`id`, `name`). |
+| `breadcrumb` | array \| null | Canonical project-root-to-container path (`id`, `name`, `sessionType`). |
 
-**File / folder / project** items additionally carry: `fileName`, `fileFormat` (file only), `sessionId` (parent project/folder), `entitySessionId` (owning entity, if any). **Folder / project** items also carry `sessionName` — the clean display name. Use it for display rather than deriving a name from `snippets`/row text, which mix the name with tags (folders) or description + tags (projects).
+Canonical context objects use these exact wire shapes:
+
+| Object | Exact shape |
+| --- | --- |
+| `container` | `{ id: string, name: string, kind: "folder" \| "project" }` |
+| `project` | `{ id: string, name: string }` |
+| `breadcrumb[]` | `{ id: string, name: string, sessionType: "creative_project" \| "session" }` |
+
+The `container`, `project`, and `breadcrumb` keys are required on every search
+item but nullable as one all-or-nothing context unit. Project and asset results
+use null context. File and folder results always carry a complete canonical
+context unit; hits whose current lineage is missing, deleted, malformed, stale,
+or unauthorized are omitted rather than returned with null or partial hierarchy
+metadata. For file and folder results, use these canonical names and IDs instead
+of deriving hierarchy from snippets or denormalized index fields.
+
+`container` has the exact shape `{ id, name, kind }`, where `kind` is `folder`
+or `project`. Only a `folder` container ID belongs in a
+`/folders/{containerId}` URL; a `project` container is the project root and
+belongs in `/projects/{containerId}`.
+
+**File / folder / project** items may additionally carry `fileName`,
+`fileFormat` (file only), `sessionId`, and `entitySessionId` (owning entity, if
+any). For a file, `sessionId` is its current canonical containing folder or
+project. For a folder or project result, `sessionId` identifies the matched
+session itself; determine parentage only from `container` and `breadcrumb`.
+**Folder / project** items also carry `sessionName` — the clean display name.
+Use it for display rather than deriving a name from `snippets`/row text, which
+mix the name with tags (folders) or description + tags (projects).
 
 **Asset** items instead carry asset-specific fields (no `fileName`/`fileFormat`):
 
@@ -99,25 +132,38 @@ Each entry in `matches[]`:
 | `lineStart` | integer? | Starting line number of the chunk (content rows) |
 
 ```bash
-# Find files named/containing "hero"
+# Find files with any analyzed term from "hero"
 curl "https://data.spuree.com/api/v1/search?q=hero&type=file" \
   -H "Authorization: Bearer $SPUREE_ACCESS_TOKEN"
 
-# Search only file names, restricted to one project, txt/md only
-curl "https://data.spuree.com/api/v1/search?q=quarterly%20report&type=file&searchIn=name&projectId=...&format=txt,md&limit=50" \
+# Search file names for an exact analyzed phrase, restricted to one project
+curl "https://data.spuree.com/api/v1/search?q=quarterly%20report&type=file&searchIn=name&matchMode=phrase&projectId=...&format=txt,md&limit=50" \
   -H "Authorization: Bearer $SPUREE_ACCESS_TOKEN"
 
-# Next page
-curl "https://data.spuree.com/api/v1/search?q=hero&cursor=<token>" \
+# Next page: replay the original query and corpus-shaping parameters
+curl "https://data.spuree.com/api/v1/search?q=hero&type=file&cursor=<token>" \
   -H "Authorization: Bearer $SPUREE_ACCESS_TOKEN"
 ```
 
-**Errors specific to search:**
+Newly issued cursors also bind the caller's current permission scope. Treat a
+cursor as opaque; do not edit or reuse it with a different query, source type,
+filter set, or caller. A malformed or mismatched bound cursor returns 422.
+Pre-`matchMode` legacy cursors are treated as unbound `any`-mode compatibility
+tokens, regardless of a re-sent `matchMode`, so keep one only within its
+original pagination sequence. Newly issued cursors remain bound and reject a
+mismatched corpus.
 
-| Code | messageCode | Cause | Resolution |
-| --- | --- | --- | --- |
-| 400 | `search_query_too_broad` | Query would match more than ~100,000 rows. Body includes `lowerBound` and `threshold`. | Prompt the user to refine with more specific terms. |
-| 422 | — | Missing/invalid `q`, naive (timezone-less) `createdAfter`/`createdBefore`, or malformed `workspaceId`/`projectId`. | Fix the parameter. |
+**Status Codes:**
+
+| Code | Description |
+| --- | --- |
+| 200 | One canonical search page returned. |
+| 400 | `search_query_too_broad`: query would match at least the bounded threshold; refine the terms. |
+| 401 | Invalid or expired credential. |
+| 403 | OAuth credential lacks the `read` scope. |
+| 422 | Missing/invalid parameter, timezone-less date, malformed narrowing ID, or malformed/mismatched cursor. |
+| 500 | Non-transient search or canonical-storage failure. |
+| 503 | `search_context_unavailable`: canonical validation could not safely advance a stale-only page. |
 
 ---
 
@@ -433,19 +479,19 @@ When a user wants to **view**, **preview**, or **see** a file:
 
 1. If the agent has browser tools (e.g., Chrome DevTools MCP), **open the Studio preview URL directly**:
    ```
-   navigate_page → https://studio.spuree.com/file/{fileId}
+   navigate_page → https://studio.spuree.com/files/{fileId}
    ```
 
 2. Otherwise, **return the Studio preview URL** for the user to click:
    ```
-   https://studio.spuree.com/file/{fileId}
+   https://studio.spuree.com/files/{fileId}
    ```
 
 Do **not** download the file or attempt to open it locally. The Studio URL is permanent, permission-aware, and renders images, video, 3D, and other supported formats inline in the browser.
 
 | Use case | URL | Properties |
 | --- | --- | --- |
-| **Share with user / preview** | `https://studio.spuree.com/file/{fileId}` | Permanent, permission-aware, renders preview UI |
+| **Share with user / preview** | `https://studio.spuree.com/files/{fileId}` | Permanent, permission-aware, renders preview UI |
 | **Programmatic download** | `downloadUrl` from `GET /v1/files/{fileId}` | Short-lived presigned S3 URL — do not share, bypasses permissions and expires |
 
 **Rule of thumb:** after `POST /v1/files` (upload) build the Studio URL from the returned `fileId`; after `GET /v1/search` use the result's `sourceId` (the file id, for `sourceType: "file"` items). Return that URL to the user. Only fetch `downloadUrl` when the agent itself needs the bytes.
@@ -467,9 +513,8 @@ S3 key: `works_{workspaceId}/sess_{sessionId}/file_{fileId}`
 | Resource | URL Pattern |
 | --- | --- |
 | Project | `https://studio.spuree.com/projects/{projectId}` |
-| Folder (top-level) | `https://studio.spuree.com/projects/{projectId}/folders/{folderId}` |
-| Folder (nested) | `.../folders/{parentId}/{childId}` (up to 5 levels) |
-| File | `https://studio.spuree.com/file/{fileId}` |
+| Folder | `https://studio.spuree.com/folders/{folderId}` |
+| File | `https://studio.spuree.com/files/{fileId}` |
 
 ## Error Handling
 

--- a/file-management/SKILL.md
+++ b/file-management/SKILL.md
@@ -64,6 +64,10 @@ and uses an opaque cursor for pagination.
 
 **Response:** `{ "data": [...], "count": N, "cursor": "<opaque token or null>" }`
 
+Continue pagination whenever `cursor` is non-null, even when `count` is smaller
+than the requested `limit`; canonical validation can suppress stale hits and
+produce a short page that still has another page.
+
 Each `data` item is one matched source object. Common fields:
 
 | Field | Type | Description |
@@ -148,7 +152,9 @@ curl "https://data.spuree.com/api/v1/search?q=hero&type=file&cursor=<token>" \
 Newly issued HMAC-signed `v1` cursors also bind the caller's current permission
 scope. Treat a cursor as opaque; do not edit or reuse it with a different query,
 source type, filter set, or caller. A malformed, tampered, or mismatched bound
-cursor returns 422.
+cursor returns 422. If a previously valid cursor returns 422 after the caller's
+permission scope changes, discard it and restart from page one with the same
+query and filters; do not retry the rejected cursor.
 
 Unsigned pre-v1 cursors are treated as unbound `any`-mode compatibility tokens,
 regardless of a re-sent `matchMode`, only until **2026-09-07 00:00 UTC**. During

--- a/folder-management/SKILL.md
+++ b/folder-management/SKILL.md
@@ -202,12 +202,12 @@ silently traversing project trees.
 | Code | Description |
 | --- | --- |
 | 200 | Complete or explicitly partial canonical candidates returned |
-| 400 | Query has no safe high-signal term or exceeds the bounded search breadth threshold |
+| 400 | `search_query_too_broad`: query has no safe high-signal term or exceeds the bounded search breadth threshold |
 | 401 | Invalid or expired credential |
 | 403 | OAuth credential lacks the `read` scope |
 | 422 | Missing/blank query, invalid limit, or malformed narrowing ID |
 | 500 | Non-transient search or canonical-storage failure |
-| 503 | Shared request deadline expires, both evidence branches are unavailable, or canonical hydration fails |
+| 503 | `folder_discovery_unavailable`: shared request deadline expires, both evidence branches are unavailable, or canonical hydration fails |
 
 **Example:**
 
@@ -802,44 +802,60 @@ Do not list every project or walk child endpoints to discover a folder by name.
    `breadcrumb`. Preserve explicit partial status. Return or ask the user to
    choose among those candidates; do not perform client-side traversal.
 
-2. **Compatibility fallback only:** if an older deployment does not expose
-   `GET /v1/search/folders`, use the following fixed two-search sequence. First
-   separate the likely leaf-folder stem and requested leaf labels from hierarchy
-   qualifiers. In the example above, search for `Phase`, retain the requested
-   labels `0` and `A`, and use `PLOCAN` / `Works` as hierarchy qualifiers. Rank
-   canonical `Phase 0` and `Phase A` results beneath `PLOCAN / Works`; do not
-   treat `Works` as the leaf. Do not send request verbs or the entire
+2. **Compatibility fallback only:** use the following fixed legacy sequence
+   only when the client tool registry does not contain `folder_find`, or an HTTP
+   request to `GET /v1/search/folders` returns 404 or 405. Those conditions
+   confirm that the endpoint is absent. Do not fall back after a 400, 401, 403,
+   422, 500, or 503 response, a timeout, or a network failure; surface that
+   error instead.
+
+   A deployment old enough to lack `folder_find` also lacks `matchMode` and may
+   not return canonical `container`, `project`, or `breadcrumb` context from
+   generic search. First separate the likely leaf-folder stem and requested
+   leaf labels from hierarchy qualifiers. In the example above, search for
+   `Phase`, retain the requested labels `0` and `A`, and keep `PLOCAN` / `Works`
+   only as user-provided qualifiers. Do not claim that a result is beneath
+   `PLOCAN / Works` unless the response itself supplies canonical context, and
+   do not treat `Works` as the leaf. Do not send request verbs or the entire
    natural-language sentence as `{encodedQuery}`.
 
    Search folder name rows directly:
 
    ```text
-   GET /v1/search?q={encodedQuery}&type=folder&searchIn=name&matchMode=all&limit=50
+   GET /v1/search?q={encodedQuery}&type=folder&searchIn=name&limit=50
    ```
 
-   Read the grouped `{ data, count, cursor }` response. Rank an exact
-   case-insensitive `sessionName` match first, then normalized all-term name
+   Read the grouped `{ data, count, cursor }` response. Each direct folder
+   result proves that its `sourceId` is a folder ID. Rank an exact
+   case-insensitive `sessionName` match first, then normalized requested-label
    matches, then the API relevance order. A folder result's canonical Studio
-   URL is `https://studio.spuree.com/folders/{sourceId}`.
+   URL is `https://studio.spuree.com/folders/{sourceId}`. Treat a legacy
+   `projectId` as an opaque identifier; do not invent a project name or folder
+   path when canonical context is absent.
 
-   Only when the direct results are empty or still ambiguous and the request
-   contains useful file/content terms, make **one** evidence fallback request:
+   Only when the direct search returned at least two plausible folder
+   candidates, the result is still ambiguous, and the request contains useful
+   file/content terms, make **one** evidence fallback request. If direct search
+   returned no folder candidates, stop and ask for a narrower name or project;
+   file evidence cannot establish a folder identity by itself.
 
    ```text
-   GET /v1/search?q={encodedQuery}&type=file&searchIn=all&matchMode=all&limit=50
+   GET /v1/search?q={encodedQuery}&type=file&searchIn=all&limit=50
    ```
 
-   Use concise evidence terms, not request verbs. Group the returned file
-   results by their containing `sessionId`; use the number and relevance of
-   matching files only as supporting evidence. Promote a group only when its
-   result context identifies that `sessionId` as a folder, and skip
-   project-root files. Its canonical Studio URL is
-   `https://studio.spuree.com/folders/{sessionId}`.
+   Use concise evidence terms, not request verbs. Build a set of the direct
+   folder results' `sourceId` values, then group returned file results by their
+   containing `sessionId`. Count a file group only when its `sessionId` is in
+   that direct-folder ID set. File evidence may re-rank an already-proven direct
+   folder candidate, but it must never introduce a new folder candidate or
+   establish hierarchy. This intersection also excludes project-root files,
+   because a project ID was not returned as a direct folder `sourceId`.
 
-   Return the best candidates with their project context and evidence. If the
-   result is still ambiguous, ask the user to choose. Stop after the direct
-   search and the single fallback: do not enumerate projects, call child
-   endpoints, or recursively traverse folders for named-folder discovery.
+   Return the best candidates with only the context actually present and the
+   supporting evidence counts. If the result is still ambiguous, ask the user
+   to choose. Stop after the direct search and the single fallback: do not
+   enumerate projects, call child endpoints, or recursively traverse folders
+   for named-folder discovery.
 
 `GET /v1/folders` is for globally sorted listing such as “recent folders”; it
 is not the fallback for a name query.

--- a/folder-management/SKILL.md
+++ b/folder-management/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: folder-management
-description: List recent folders across projects; create, update, delete, and browse folders (sessions), including assets, files, and batch downloads
+description: Find folders by name, list recent folders across projects, and create, update, delete, or browse folders (sessions), including their assets and files
 ---
 
 # Folder Management
@@ -12,6 +12,7 @@ Spuree is an agent-friendly cloud storage. Projects contain folders (nestable) a
 Use this skill when an agent needs to:
 
 - List recently created or updated folders across all accessible projects
+- Find a named folder with bounded search rather than project-tree traversal
 - Create, rename, move, or delete folders in a project
 - Browse a folder's contents (sub-folders, entities, files)
 - List assets or files within a folder
@@ -37,6 +38,7 @@ See the **authentication** skill for obtaining tokens and managing API keys.
 
 | Operation | Base URL |
 | --- | --- |
+| Named-folder discovery | `https://data.spuree.com/api/v1/search/folders` |
 | Cross-project folder listing | `https://data.spuree.com/api/v1/folders` |
 | Folder CRUD and child browsing | `https://data.spuree.com/api/v1/sessions` |
 
@@ -73,6 +75,148 @@ Entities represent assets and have one of these types:
 `character`, `motion`, `prop`, `environment`, `visdev`, `pose`
 
 ## Endpoints
+
+### GET /v1/search/folders
+
+<!-- spuree-agent
+surfaces: ["local", "desktop", "backend", "hosted-web"]
+webSafe: true
+-->
+
+Find existing project folders in one bounded request. The Search service runs
+direct folder-name and contained-file evidence branches concurrently under the
+same caller scope and eight-second ceiling, then returns deduplicated canonical
+folders. Use this endpoint first for a named-folder request; do not enumerate
+projects or recursively browse children to reproduce it client-side.
+
+**Query Parameters:**
+
+| Parameter | Type | Required | Default | Description |
+| --- | --- | --- | --- | --- |
+| `q` | string | Yes | — | Nonblank natural-language folder query (1–255 characters). |
+| `workspaceId` | string | No | — | Restrict to one workspace already accessible to the caller. |
+| `projectId` | string | No | — | Restrict to one project already accessible to the caller. |
+| `limit` | integer | No | 5 | Maximum canonical candidates (1–10). |
+
+**Response:**
+
+```json
+{
+  "data": [
+    {
+      "folder": { "id": "64a7b8c9d1e2f3a4b5c6d7e8", "name": "Phase 0" },
+      "project": { "id": "64a7b8c9d1e2f3a4b5c6d7d0", "name": "PLOCAN" },
+      "breadcrumb": [
+        { "id": "64a7b8c9d1e2f3a4b5c6d7d0", "name": "PLOCAN", "sessionType": "creative_project" },
+        { "id": "64a7b8c9d1e2f3a4b5c6d7d8", "name": "Works", "sessionType": "session" },
+        { "id": "64a7b8c9d1e2f3a4b5c6d7e8", "name": "Phase 0", "sessionType": "session" }
+      ],
+      "matchStrength": "strong",
+      "reasonCodes": ["direct_folder_name", "path_token_match"],
+      "evidence": {
+        "directMatchCount": 1,
+        "childFileCount": 0,
+        "childFilenameCount": 0,
+        "childContentCount": 0
+      }
+    }
+  ],
+  "count": 1,
+  "status": "complete",
+  "partial": false,
+  "degradedBranches": [],
+  "branchStatus": [
+    { "branch": "direct_folder_name", "status": "ok" },
+    { "branch": "file_evidence", "status": "ok" }
+  ]
+}
+```
+
+The documented response schema is exact:
+
+| Object | Field | Type |
+| --- | --- | --- |
+| `envelope` | `data` | array |
+| `envelope` | `count` | integer |
+| `envelope` | `status` | string |
+| `envelope` | `partial` | boolean |
+| `envelope` | `degradedBranches` | string[] |
+| `envelope` | `branchStatus` | array |
+| `result` | `folder` | object |
+| `result` | `project` | object |
+| `result` | `breadcrumb` | array |
+| `result` | `matchStrength` | string |
+| `result` | `reasonCodes` | string[] |
+| `result` | `evidence` | object |
+| `folder` | `id` | string |
+| `folder` | `name` | string |
+| `project` | `id` | string |
+| `project` | `name` | string |
+| `breadcrumb[]` | `id` | string |
+| `breadcrumb[]` | `name` | string |
+| `breadcrumb[]` | `sessionType` | string |
+| `evidence` | `directMatchCount` | integer |
+| `evidence` | `childFileCount` | integer |
+| `evidence` | `childFilenameCount` | integer |
+| `evidence` | `childContentCount` | integer |
+| `branchStatus[]` | `branch` | string |
+| `branchStatus[]` | `status` | string |
+
+The response enums are also closed sets:
+
+| Field | Exact values |
+| --- | --- |
+| `status` | `complete` \| `partial` |
+| `degradedBranches[]` | `direct_folder_name` \| `file_evidence` |
+| `matchStrength` | `exact` \| `strong` \| `supporting` |
+| `reasonCodes[]` | `exact_folder_name` \| `direct_folder_name` \| `path_token_match` \| `child_filename` \| `child_content` |
+| `breadcrumb[].sessionType` | `creative_project` \| `session` |
+| `branchStatus[].branch` | `direct_folder_name` \| `file_evidence` |
+| `branchStatus[].status` | `ok` \| `timeout` \| `error` \| `skipped` |
+
+`breadcrumb` is ordered from the creative-project root through the matched
+folder. `matchStrength` is exactly `exact`, `strong`, or `supporting`; it is a
+stable qualitative tier, not a probability. `reasonCodes` may contain
+`exact_folder_name`, `direct_folder_name`, `path_token_match`,
+`child_filename`, and `child_content`.
+
+Evidence is count-only. CheehooData does not return matching child file names,
+file IDs, snippets, bodies, raw Atlas scores, or navigation URLs from this
+endpoint. A hosted Studio tool may add `webUrl` fields; otherwise construct
+`https://studio.spuree.com/folders/{folderId}` and
+`https://studio.spuree.com/projects/{projectId}` from the canonical IDs.
+
+`status: "partial"` and `partial: true` mean exactly one search branch degraded;
+inspect `degradedBranches` and `branchStatus`, and present the surviving
+candidates as partial. Each `branchStatus[].status` is exactly `ok`, `timeout`,
+`error`, or `skipped`: `ok` means the bounded branch completed (even with no
+matches), `timeout`/`error` identify degradation, and `skipped` means no search
+ran because the caller's narrowed scope was empty. Service construction, scope
+resolution, both evidence branches, and canonical hydration share one
+eight-second ceiling. If that request budget expires, both branches are
+unavailable, or canonical hydration fails, the request returns 503 instead of
+silently traversing project trees.
+
+**Status Codes:**
+
+| Code | Description |
+| --- | --- |
+| 200 | Complete or explicitly partial canonical candidates returned |
+| 400 | Query has no safe high-signal term or exceeds the bounded search breadth threshold |
+| 401 | Invalid or expired credential |
+| 403 | OAuth credential lacks the `read` scope |
+| 422 | Missing/blank query, invalid limit, or malformed narrowing ID |
+| 500 | Non-transient search or canonical-storage failure |
+| 503 | Shared request deadline expires, both evidence branches are unavailable, or canonical hydration fails |
+
+**Example:**
+
+```bash
+curl "https://data.spuree.com/api/v1/search/folders?q=PLOCAN%20Phase%200%20and%20A%20Works&limit=5" \
+  -H "Authorization: Bearer $SPUREE_ACCESS_TOKEN"
+```
+
+---
 
 ### GET /v1/folders
 
@@ -375,7 +519,8 @@ List a folder's immediate contents — sub-folders, asset entities, and files. U
 }
 ```
 
-> **Parsing note:** Read the `items` array. **Do not** look for separate top-level `sessions`, `entities`, or `files` arrays — older deployments returned that shape, but the current API returns the unified `items` list, so a parser expecting the old shape sees an empty result and wrongly concludes the folder is empty. For backward compatibility, a robust parser can read `items` first and fall back to the legacy `sessions`/`entities`/`files` arrays only when `items` is absent.
+> **Parsing note:** Read the required top-level `items` array. Do not parse this
+> endpoint as separate collections; an empty folder is exactly `{ "items": [] }`.
 
 **Item Types** (selected by `type`):
 
@@ -641,7 +786,68 @@ folders, and do not recurse through every project's children.
 GET /v1/folders?sortBy=createdAt&sortOrder=desc&limit=20
 ```
 
-### Navigate a Project's Folder Structure
+### Find a Named Folder (Bounded Search-First Recipe)
+
+Use search for requests such as “find the PLOCAN Phase 0 and A Works folder.”
+Do not list every project or walk child endpoints to discover a folder by name.
+
+1. Make the preferred one-call discovery request with the user's concise
+   natural-language folder intent:
+
+   ```text
+   GET /v1/search/folders?q={encodedNaturalLanguageQuery}&limit=5
+   ```
+
+   Use the returned canonical `folder`, `project`, and root-to-folder
+   `breadcrumb`. Preserve explicit partial status. Return or ask the user to
+   choose among those candidates; do not perform client-side traversal.
+
+2. **Compatibility fallback only:** if an older deployment does not expose
+   `GET /v1/search/folders`, use the following fixed two-search sequence. First
+   separate the likely leaf-folder stem and requested leaf labels from hierarchy
+   qualifiers. In the example above, search for `Phase`, retain the requested
+   labels `0` and `A`, and use `PLOCAN` / `Works` as hierarchy qualifiers. Rank
+   canonical `Phase 0` and `Phase A` results beneath `PLOCAN / Works`; do not
+   treat `Works` as the leaf. Do not send request verbs or the entire
+   natural-language sentence as `{encodedQuery}`.
+
+   Search folder name rows directly:
+
+   ```text
+   GET /v1/search?q={encodedQuery}&type=folder&searchIn=name&matchMode=all&limit=50
+   ```
+
+   Read the grouped `{ data, count, cursor }` response. Rank an exact
+   case-insensitive `sessionName` match first, then normalized all-term name
+   matches, then the API relevance order. A folder result's canonical Studio
+   URL is `https://studio.spuree.com/folders/{sourceId}`.
+
+   Only when the direct results are empty or still ambiguous and the request
+   contains useful file/content terms, make **one** evidence fallback request:
+
+   ```text
+   GET /v1/search?q={encodedQuery}&type=file&searchIn=all&matchMode=all&limit=50
+   ```
+
+   Use concise evidence terms, not request verbs. Group the returned file
+   results by their containing `sessionId`; use the number and relevance of
+   matching files only as supporting evidence. Promote a group only when its
+   result context identifies that `sessionId` as a folder, and skip
+   project-root files. Its canonical Studio URL is
+   `https://studio.spuree.com/folders/{sessionId}`.
+
+   Return the best candidates with their project context and evidence. If the
+   result is still ambiguous, ask the user to choose. Stop after the direct
+   search and the single fallback: do not enumerate projects, call child
+   endpoints, or recursively traverse folders for named-folder discovery.
+
+`GET /v1/folders` is for globally sorted listing such as “recent folders”; it
+is not the fallback for a name query.
+
+### Browse a Known Folder
+
+Use child endpoints only after the user supplied or selected an ID. They are
+for inspecting a known container, not for finding a named folder.
 
 1. **Get project children** (via **project-management** skill):
 
@@ -655,7 +861,7 @@ GET /v1/folders?sortBy=createdAt&sortOrder=desc&limit=20
    GET /v1/sessions/{folderId}/children → { items: [...] }
    ```
 
-3. **Repeat** to go deeper into sub-folders.
+3. Follow a returned sub-folder ID only when the user asks to inspect it.
 
 ### Create a Folder Structure
 
@@ -688,7 +894,7 @@ POST /v1/sessions { name: "Heroes", parentSessionId: "folder1" }
 
 ### Agent Workflow: Asset Discovery
 
-1. **Browse project** → find the folder containing assets
+1. **Find the folder** → use the bounded search-first recipe above
 2. **Get assets** → `GET /v1/sessions/{folderId}/assets`
 3. **Get files** → for each asset, list its files
 4. **Download** → batch download with `POST /v1/sessions/files/download/urls`
@@ -700,11 +906,10 @@ After creating or finding resources, you can give the user a clickable link to v
 | Resource | URL Pattern |
 | --- | --- |
 | Project | `https://studio.spuree.com/projects/{projectId}` |
-| Folder (top-level) | `https://studio.spuree.com/projects/{projectId}/folders/{folderId}` |
-| Folder (nested) | `https://studio.spuree.com/projects/{projectId}/folders/{parentId}/{childId}` |
-| File | `https://studio.spuree.com/file/{fileId}` |
+| Folder | `https://studio.spuree.com/folders/{folderId}` |
+| File | `https://studio.spuree.com/files/{fileId}` |
 
-Folders support up to 5 levels of nesting. Each level appends another ID segment: `.../folders/{level1}/{level2}/{level3}/...`
+Studio resource URLs use only the target ID, regardless of folder depth.
 
 ## Error Handling
 

--- a/folder-management/SKILL.md
+++ b/folder-management/SKILL.md
@@ -850,6 +850,11 @@ Do not list every project or walk child endpoints to discover a folder by name.
    folder candidate, but it must never introduce a new folder candidate or
    establish hierarchy. This intersection also excludes project-root files,
    because a project ID was not returned as a direct folder `sourceId`.
+   Nested descendant files are a known blind spot of this legacy evidence
+   step: without canonical lineage, they cannot safely count toward an ancestor
+   folder candidate. Treat zero direct-file evidence as inconclusive, not as
+   proof that a folder is empty or irrelevant, and do not traverse descendants
+   to compensate.
 
    Return the best candidates with only the context actually present and the
    supporting evidence counts. If the result is still ambiguous, ask the user

--- a/folder-management/SKILL.md
+++ b/folder-management/SKILL.md
@@ -804,7 +804,7 @@ Do not list every project or walk child endpoints to discover a folder by name.
 
 2. **Compatibility fallback only:** use the following fixed legacy sequence
    only when the client tool registry does not contain `folder_find`, or an HTTP
-   request to `GET /v1/search/folders` returns 404 or 405. Those conditions
+   request to `GET /v1/search/folders` returns 404, 405, or 501. Those conditions
    confirm that the endpoint is absent. Do not fall back after a 400, 401, 403,
    422, 500, or 503 response, a timeout, or a network failure; surface that
    error instead.

--- a/getting-started/SKILL.md
+++ b/getting-started/SKILL.md
@@ -26,8 +26,10 @@ First identify what the user asked for:
 Then adapt to the capabilities available in the current client:
 
 - **Full MCP or locally installed skills:** Use `project_list`, or delegate to
-  **project-management**, for the read-only first success. Other project, folder,
-  file, and invitation actions may also be available.
+  **project-management**, for a general read-only connection check. When the
+  user names something to find, use search first and delegate named-folder
+  discovery to the bounded recipe in **folder-management**. Other project,
+  folder, file, and invitation actions may also be available.
 - **Search/fetch web connector:** Some ChatGPT connections expose only `search`,
   `fetch`, and `getting_started`. Explain that this surface is read-only. Ask what
   the user wants to find, call `search`, and use `fetch` to read the selected
@@ -45,6 +47,9 @@ Phrase these as examples the user can ask for, not as API names.
 - “Find files or folders about the hero character.”
 - “Show me what is inside this project or folder.”
 - “Read this text, Markdown, JSON, CSV, or source file.”
+
+Named discovery is search-first. It does not require listing every project or
+walking an entire folder tree.
 
 **Organize**
 
@@ -71,7 +76,11 @@ internal creator capabilities such as motion or video generation.
 
 ### Phase 1 — Get a read-only first success
 
-Prefer listing projects:
+If the user already supplied a name or topic, prefer a read-only search. For a
+folder request, use the one-call `folder_find` recipe in **folder-management**.
+Only when an older deployment does not expose that tool, use its fixed generic
+search fallback with `type=folder`, `searchIn=name`, and `matchMode=all`.
+Otherwise, use a small project list as a generic connection check:
 
 1. Tell the user you will check their Spuree connection.
 2. Call `project_list`, or use **project-management** to list projects.
@@ -94,7 +103,12 @@ Translate failures into plain guidance:
 
 If projects can be listed, let the user choose one, then use `project_browse` or
 the **project-management** skill to show its immediate contents. Continue into a
-folder with `folder_browse` or **folder-management** only when the user asks.
+known folder with `folder_browse` or **folder-management** only when the user
+asks. If the user gives a folder name instead, prefer the one-call
+`folder_find` workflow documented by **folder-management**. Only an older
+deployment that lacks that endpoint may use its fixed two-search compatibility
+fallback; never enumerate projects or recursively traverse children to discover
+the folder.
 
 On the search/fetch connector, let the user choose a search result and call
 `fetch` to read it.

--- a/getting-started/SKILL.md
+++ b/getting-started/SKILL.md
@@ -78,8 +78,8 @@ internal creator capabilities such as motion or video generation.
 
 If the user already supplied a name or topic, prefer a read-only search. For a
 folder request, use the one-call `folder_find` recipe in **folder-management**.
-Only when the tool registry lacks `folder_find`, or the endpoint returns 404 or
-405, use its fixed legacy generic-search fallback with `type=folder` and
+Only when the tool registry lacks `folder_find`, or the endpoint returns 404,
+405, or 501, use its fixed legacy generic-search fallback with `type=folder` and
 `searchIn=name`. Do not fall back after another response or transport failure.
 Otherwise, use a small project list as a generic connection check:
 

--- a/getting-started/SKILL.md
+++ b/getting-started/SKILL.md
@@ -78,8 +78,9 @@ internal creator capabilities such as motion or video generation.
 
 If the user already supplied a name or topic, prefer a read-only search. For a
 folder request, use the one-call `folder_find` recipe in **folder-management**.
-Only when an older deployment does not expose that tool, use its fixed generic
-search fallback with `type=folder`, `searchIn=name`, and `matchMode=all`.
+Only when the tool registry lacks `folder_find`, or the endpoint returns 404 or
+405, use its fixed legacy generic-search fallback with `type=folder` and
+`searchIn=name`. Do not fall back after another response or transport failure.
 Otherwise, use a small project list as a generic connection check:
 
 1. Tell the user you will check their Spuree connection.
@@ -106,9 +107,9 @@ the **project-management** skill to show its immediate contents. Continue into a
 known folder with `folder_browse` or **folder-management** only when the user
 asks. If the user gives a folder name instead, prefer the one-call
 `folder_find` workflow documented by **folder-management**. Only an older
-deployment that lacks that endpoint may use its fixed two-search compatibility
-fallback; never enumerate projects or recursively traverse children to discover
-the folder.
+deployment confirmed to lack that endpoint may use its fixed two-search
+compatibility fallback; never enumerate projects or recursively traverse
+children to discover the folder.
 
 On the search/fetch connector, let the user choose a search result and call
 `fetch` to read it.

--- a/project-management/SKILL.md
+++ b/project-management/SKILL.md
@@ -288,12 +288,16 @@ curl -X POST "https://data.spuree.com/api/v1/projects/{projectId}/leave" \
 For a named project, search its name directly:
 
 ```text
-GET /v1/search?q={encodedQuery}&type=project&searchIn=name&matchMode=all&limit=50
+GET /v1/search?q={encodedQuery}&type=project&searchIn=name&limit=50
 ```
 
 Read the grouped `{ data, count, cursor }` response and use each project
-result's `sourceId`. Do not enumerate every project's children to discover a
-project or folder. For a named folder, use the bounded recipe in
+result's `sourceId`. This compatibility-safe recipe intentionally omits
+`matchMode`, because generic search may target a deployment that predates that
+parameter. Rank an exact case-insensitive `sessionName` match first, then a
+normalized full-name match, then API relevance; ask the user to choose if the
+result remains ambiguous. Do not enumerate every project's children to
+discover a project or folder. For a named folder, use the bounded recipe in
 **folder-management**.
 
 ### Studio URLs

--- a/project-management/SKILL.md
+++ b/project-management/SKILL.md
@@ -199,7 +199,8 @@ List a project's immediate contents — folders, asset entities, and files — a
 | `entity` | Asset | `entityType` (character, motion, prop, etc.), `entityPreview` (preview image) |
 | `file` | File | `name` (mirrors the file's `fileName`), `fileFormat`, `fileSize`, `key`, `presignedUrl` (download URL) |
 
-> **Parsing note:** Read the `items` array. **Do not** look for separate top-level `sessions`, `entities`, or `files` arrays — older deployments returned that shape, but the current API returns the unified `items` list, so a parser expecting the old shape sees an empty result and wrongly concludes the project is empty. For backward compatibility, a robust parser can read `items` first and fall back to the legacy `sessions`/`entities`/`files` arrays only when `items` is absent.
+> **Parsing note:** Read the required top-level `items` array. Do not parse this
+> endpoint as separate collections; an empty project is exactly `{ "items": [] }`.
 
 ```bash
 curl "https://data.spuree.com/api/v1/projects/{projectId}/children" \
@@ -277,24 +278,31 @@ curl -X POST "https://data.spuree.com/api/v1/projects/{projectId}/leave" \
 
 ### Browse a Project
 
-1. `GET /v1/projects` → find the target project
-2. `GET /v1/projects/{id}/children` → see contents
-3. `GET /v1/sessions/{folderId}/children` → navigate deeper (folder-management skill)
+1. Start with a project ID the user supplied or selected.
+2. `GET /v1/projects/{id}/children` → inspect its immediate contents.
+3. `GET /v1/sessions/{folderId}/children` → inspect a selected folder
+   (folder-management skill).
 
 ### Agent Workflow: Project Discovery
 
-1. **List projects** → find the target
-2. **Get children** → browse recursively
-3. Use IDs with: **folder-management**, **file-management**
+For a named project, search its name directly:
+
+```text
+GET /v1/search?q={encodedQuery}&type=project&searchIn=name&matchMode=all&limit=50
+```
+
+Read the grouped `{ data, count, cursor }` response and use each project
+result's `sourceId`. Do not enumerate every project's children to discover a
+project or folder. For a named folder, use the bounded recipe in
+**folder-management**.
 
 ### Studio URLs
 
 | Resource | URL Pattern |
 | --- | --- |
 | Project | `https://studio.spuree.com/projects/{projectId}` |
-| Folder (top-level) | `https://studio.spuree.com/projects/{projectId}/folders/{folderId}` |
-| Folder (nested) | `.../folders/{parentId}/{childId}` (up to 5 levels) |
-| File | `https://studio.spuree.com/file/{fileId}` |
+| Folder | `https://studio.spuree.com/folders/{folderId}` |
+| File | `https://studio.spuree.com/files/{fileId}` |
 
 ## Error Handling
 

--- a/scripts/check-folder-discovery-contract.mjs
+++ b/scripts/check-folder-discovery-contract.mjs
@@ -870,7 +870,7 @@ function validateBoundedRecipe(folderMarkdown, errors) {
   addError(
     errors,
     /tool registry does not contain `folder_find`/.test(section) &&
-      /returns 404 or 405/.test(section),
+      /returns 404, 405, or 501/.test(section),
     "folder-management: compatibility fallback must require confirmed endpoint absence",
   );
   addError(
@@ -979,7 +979,7 @@ export function validateFolderDiscoveryContract(documents) {
   addError(
     errors,
     /tool registry lacks `folder_find`/.test(documents.gettingStarted) &&
-      /endpoint returns 404 or\s+405/.test(documents.gettingStarted) &&
+      /endpoint returns 404,\s+405, or 501/.test(documents.gettingStarted) &&
       /Do not fall back after another response or transport failure/.test(documents.gettingStarted),
     "getting-started: compatibility fallback must be absence-only",
   );

--- a/scripts/check-folder-discovery-contract.mjs
+++ b/scripts/check-folder-discovery-contract.mjs
@@ -7,6 +7,8 @@ import { fileURLToPath } from "node:url";
 const SCRIPT_PATH = fileURLToPath(import.meta.url);
 const DEFAULT_ROOT = path.resolve(path.dirname(SCRIPT_PATH), "..");
 
+export const LEGACY_CURSOR_SUNSET_ISO = "2026-09-07T00:00:00.000Z";
+
 export const SKILL_FILES = Object.freeze({
   authentication: "authentication/SKILL.md",
   file: "file-management/SKILL.md",
@@ -975,7 +977,7 @@ function validateCanonicalUrls(documents, errors) {
   addError(errors, documents.file.includes("https://studio.spuree.com/files/{fileId}"), "file-management: canonical file URL is missing");
 }
 
-export function validateFolderDiscoveryContract(documents) {
+export function validateFolderDiscoveryContract(documents, { now = new Date() } = {}) {
   const errors = [];
   for (const key of Object.keys(SKILL_FILES)) {
     addError(errors, typeof documents[key] === "string", `missing skill document: ${key}`);
@@ -988,6 +990,11 @@ export function validateFolderDiscoveryContract(documents) {
   if (errors.length > 0) return errors.sort();
 
   validateSearchContract(documents.file, errors);
+  if (new Date(now).getTime() >= Date.parse(LEGACY_CURSOR_SUNSET_ISO)) {
+    errors.push(
+      `file-management: legacy cursor migration copy expired at ${LEGACY_CURSOR_SUNSET_ISO}; remove the unsigned-cursor compatibility guidance and update this guard`,
+    );
+  }
   validateFolderFindContract(documents.folder, errors);
   validateFolderListContract(documents.folder, errors);
   validateChildrenContract(documents.folder, "GET /v1/sessions/{sessionId}/children", "folder-management", errors);

--- a/scripts/check-folder-discovery-contract.mjs
+++ b/scripts/check-folder-discovery-contract.mjs
@@ -1,0 +1,967 @@
+#!/usr/bin/env node
+
+import { readFile } from "node:fs/promises";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const SCRIPT_PATH = fileURLToPath(import.meta.url);
+const DEFAULT_ROOT = path.resolve(path.dirname(SCRIPT_PATH), "..");
+
+export const SKILL_FILES = Object.freeze({
+  authentication: "authentication/SKILL.md",
+  file: "file-management/SKILL.md",
+  fileComment: "file-comment/SKILL.md",
+  folder: "folder-management/SKILL.md",
+  gettingStarted: "getting-started/SKILL.md",
+  projectInvitation: "project-invitation/SKILL.md",
+  project: "project-management/SKILL.md",
+});
+
+const CONTRACT_SKILLS = Object.freeze([
+  "file",
+  "folder",
+  "gettingStarted",
+  "project",
+]);
+
+function splitMarkdownRow(line) {
+  const trimmed = line.trim().replace(/^\|/, "").replace(/\|$/, "");
+  const cells = [];
+  let cell = "";
+
+  for (let index = 0; index < trimmed.length; index += 1) {
+    const character = trimmed[index];
+    if (character === "\\" && trimmed[index + 1] === "|") {
+      cell += "|";
+      index += 1;
+    } else if (character === "|") {
+      cells.push(cell.trim());
+      cell = "";
+    } else {
+      cell += character;
+    }
+  }
+
+  cells.push(cell.trim());
+  return cells;
+}
+
+function isSeparatorRow(line) {
+  return splitMarkdownRow(line).every((cell) => /^:?-{3,}:?$/.test(cell));
+}
+
+export function parseMarkdownTables(markdown) {
+  const lines = markdown.split(/\r?\n/);
+  const tables = [];
+
+  for (let index = 0; index < lines.length - 1; index += 1) {
+    if (!lines[index].trim().startsWith("|") || !isSeparatorRow(lines[index + 1])) {
+      continue;
+    }
+
+    const headers = splitMarkdownRow(lines[index]);
+    const rows = [];
+    index += 2;
+
+    while (index < lines.length && lines[index].trim().startsWith("|")) {
+      const cells = splitMarkdownRow(lines[index]);
+      rows.push(Object.fromEntries(headers.map((header, cellIndex) => [header, cells[cellIndex] ?? ""])));
+      index += 1;
+    }
+
+    tables.push({ headers, rows });
+    index -= 1;
+  }
+
+  return tables;
+}
+
+export function getSection(markdown, heading) {
+  const lines = markdown.split(/\r?\n/);
+  const marker = `### ${heading}`;
+  const start = lines.findIndex((line) => line.trim() === marker);
+  if (start === -1) return null;
+
+  const relativeEnd = lines
+    .slice(start + 1)
+    .findIndex((line) => line.trimStart().startsWith("### "));
+  const end = relativeEnd === -1 ? lines.length : start + 1 + relativeEnd;
+  return lines.slice(start, end).join("\n");
+}
+
+function normalizeCell(value) {
+  return value.replaceAll("`", "").replace(/\s+/g, " ").trim();
+}
+
+function codeValues(value) {
+  return [...value.matchAll(/`([^`]+)`/g)].map((match) => match[1]);
+}
+
+function numericRanges(value) {
+  return [...value.matchAll(/\b(\d+)\s*[\u2013-]\s*(\d+)\b/g)]
+    .map((match) => `${match[1]}-${match[2]}`);
+}
+
+function sameSet(actual, expected) {
+  return (
+    actual.length === expected.length &&
+    [...actual].sort().every((value, index) => value === [...expected].sort()[index])
+  );
+}
+
+function findParameterTable(section, requiredHeaders) {
+  return parseMarkdownTables(section).find((table) =>
+    requiredHeaders.every((header) => table.headers.includes(header)),
+  );
+}
+
+function findParameterRow(table, parameter) {
+  return table?.rows.find(
+    (row) => normalizeCell(row.Parameter ?? row.Field ?? "") === parameter,
+  );
+}
+
+function findFieldTable(section, firstField) {
+  return parseMarkdownTables(section).find(
+    (table) =>
+      sameSet(table.headers, ["Field", "Type", "Description"]) &&
+      normalizeCell(table.rows[0]?.Field ?? "") === firstField,
+  );
+}
+
+function findExactTable(section, headers) {
+  return parseMarkdownTables(section).find((table) => sameSet(table.headers, headers));
+}
+
+function findStatusTable(section) {
+  return parseMarkdownTables(section).find((table) =>
+    table.headers.length === 2 &&
+    table.headers[0] === "Code" &&
+    table.headers[1] === "Description",
+  );
+}
+
+function tableCodes(table) {
+  return (table?.rows ?? []).map((row) => normalizeCell(row.Code ?? ""));
+}
+
+function count(text, value) {
+  return text.split(value).length - 1;
+}
+
+function addError(errors, condition, message) {
+  if (!condition) {
+    errors.push(message);
+  }
+}
+
+function validateExactParameterContract(table, expected, label, errors) {
+  const actual = table.rows.map((row) => ({
+    name: normalizeCell(row.Parameter ?? ""),
+    type: normalizeCell(row.Type ?? ""),
+    required: normalizeCell(row.Required ?? ""),
+    defaultValue: normalizeCell(row.Default ?? ""),
+  }));
+  const expectedNames = expected.map(({ name }) => name);
+  addError(
+    errors,
+    actual.length === expected.length &&
+      actual.every((row, index) => row.name === expected[index].name),
+    `${label}: parameters must be exactly ${expectedNames.join("|")} in order`,
+  );
+
+  for (const contract of expected) {
+    const row = actual.find(({ name }) => name === contract.name);
+    addError(errors, row !== undefined, `${label}: missing ${contract.name} parameter`);
+    if (!row) continue;
+    addError(errors, row.type === contract.type, `${label}: ${contract.name} type must be ${contract.type}`);
+    addError(
+      errors,
+      row.required === contract.required,
+      `${label}: ${contract.name} required flag must be ${contract.required}`,
+    );
+    addError(
+      errors,
+      row.defaultValue === contract.defaultValue,
+      `${label}: ${contract.name} default must be ${contract.defaultValue}`,
+    );
+  }
+}
+
+function validateExactFieldContract(table, expected, label, errors) {
+  addError(errors, table !== undefined, `${label}: missing field contract table`);
+  if (!table) return;
+
+  const actual = table.rows.map((row) => ({
+    name: normalizeCell(row.Field ?? ""),
+    type: normalizeCell(row.Type ?? ""),
+  }));
+  const expectedNames = expected.map(({ name }) => name);
+  addError(
+    errors,
+    actual.length === expected.length &&
+      actual.every((row, index) => row.name === expected[index].name),
+    `${label}: fields must be exactly ${expectedNames.join("|")} in order`,
+  );
+
+  for (const contract of expected) {
+    const row = actual.find(({ name }) => name === contract.name);
+    addError(errors, row !== undefined, `${label}: missing ${contract.name} field`);
+    if (!row) continue;
+    addError(errors, row.type === contract.type, `${label}: ${contract.name} type must be ${contract.type}`);
+  }
+}
+
+function validateExactShapeContract(table, expected, label, errors) {
+  addError(errors, table !== undefined, `${label}: missing exact-shape table`);
+  if (!table) return;
+
+  const actual = table.rows.map((row) => ({
+    name: normalizeCell(row.Object ?? ""),
+    shape: normalizeCell(row["Exact shape"] ?? ""),
+  }));
+  addError(
+    errors,
+    actual.length === expected.length &&
+      actual.every((row, index) => row.name === expected[index].name),
+    `${label}: objects must be exactly ${expected.map(({ name }) => name).join("|")} in order`,
+  );
+
+  for (const contract of expected) {
+    const row = actual.find(({ name }) => name === contract.name);
+    addError(errors, row !== undefined, `${label}: missing ${contract.name} shape`);
+    if (!row) continue;
+    addError(errors, row.shape === contract.shape, `${label}: ${contract.name} shape must be ${contract.shape}`);
+  }
+}
+
+const SEARCH_PARAMETERS = Object.freeze([
+  { name: "q", type: "string", required: "Yes", defaultValue: "—" },
+  { name: "type", type: "string", required: "No", defaultValue: "—" },
+  { name: "searchIn", type: "string", required: "No", defaultValue: "all" },
+  { name: "matchMode", type: "string", required: "No", defaultValue: "any" },
+  { name: "format", type: "string", required: "No", defaultValue: "—" },
+  { name: "entityType", type: "string", required: "No", defaultValue: "—" },
+  { name: "workspaceId", type: "string", required: "No", defaultValue: "—" },
+  { name: "projectId", type: "string", required: "No", defaultValue: "—" },
+  { name: "createdAfter", type: "string", required: "No", defaultValue: "—" },
+  { name: "createdBefore", type: "string", required: "No", defaultValue: "—" },
+  { name: "limit", type: "integer", required: "No", defaultValue: "50" },
+  { name: "cursor", type: "string", required: "No", defaultValue: "—" },
+  { name: "sortBy", type: "string", required: "No", defaultValue: "relevance" },
+  { name: "sortOrder", type: "string", required: "No", defaultValue: "desc" },
+  { name: "includePreview", type: "boolean", required: "No", defaultValue: "false" },
+]);
+
+const FOLDER_FIND_PARAMETERS = Object.freeze([
+  { name: "q", type: "string", required: "Yes", defaultValue: "—" },
+  { name: "workspaceId", type: "string", required: "No", defaultValue: "—" },
+  { name: "projectId", type: "string", required: "No", defaultValue: "—" },
+  { name: "limit", type: "integer", required: "No", defaultValue: "5" },
+]);
+
+const SEARCH_ITEM_FIELDS = Object.freeze([
+  { name: "sourceType", type: "string" },
+  { name: "sourceId", type: "string" },
+  { name: "score", type: "number" },
+  { name: "matchCount", type: "integer" },
+  { name: "matches", type: "array" },
+  { name: "workspaceId", type: "string?" },
+  { name: "projectId", type: "string?" },
+  { name: "sourceCreatedAt", type: "datetime | null" },
+  { name: "container", type: "object | null" },
+  { name: "project", type: "object | null" },
+  { name: "breadcrumb", type: "array | null" },
+]);
+
+const SEARCH_MATCH_FIELDS = Object.freeze([
+  { name: "rowKind", type: "string" },
+  { name: "score", type: "number" },
+  { name: "snippets", type: "string[]" },
+  { name: "chunkIndex", type: "integer?" },
+  { name: "charOffset", type: "integer?" },
+  { name: "lineStart", type: "integer?" },
+]);
+
+const SEARCH_CONTEXT_SHAPES = Object.freeze([
+  {
+    name: "container",
+    shape: '{ id: string, name: string, kind: "folder" | "project" }',
+  },
+  { name: "project", shape: "{ id: string, name: string }" },
+  {
+    name: "breadcrumb[]",
+    shape: '{ id: string, name: string, sessionType: "creative_project" | "session" }',
+  },
+]);
+
+const FOLDER_RESPONSE_FIELDS = Object.freeze([
+  { object: "envelope", name: "data", type: "array" },
+  { object: "envelope", name: "count", type: "integer" },
+  { object: "envelope", name: "status", type: "string" },
+  { object: "envelope", name: "partial", type: "boolean" },
+  { object: "envelope", name: "degradedBranches", type: "string[]" },
+  { object: "envelope", name: "branchStatus", type: "array" },
+  { object: "result", name: "folder", type: "object" },
+  { object: "result", name: "project", type: "object" },
+  { object: "result", name: "breadcrumb", type: "array" },
+  { object: "result", name: "matchStrength", type: "string" },
+  { object: "result", name: "reasonCodes", type: "string[]" },
+  { object: "result", name: "evidence", type: "object" },
+  { object: "folder", name: "id", type: "string" },
+  { object: "folder", name: "name", type: "string" },
+  { object: "project", name: "id", type: "string" },
+  { object: "project", name: "name", type: "string" },
+  { object: "breadcrumb[]", name: "id", type: "string" },
+  { object: "breadcrumb[]", name: "name", type: "string" },
+  { object: "breadcrumb[]", name: "sessionType", type: "string" },
+  { object: "evidence", name: "directMatchCount", type: "integer" },
+  { object: "evidence", name: "childFileCount", type: "integer" },
+  { object: "evidence", name: "childFilenameCount", type: "integer" },
+  { object: "evidence", name: "childContentCount", type: "integer" },
+  { object: "branchStatus[]", name: "branch", type: "string" },
+  { object: "branchStatus[]", name: "status", type: "string" },
+]);
+
+const FOLDER_RESPONSE_ENUMS = Object.freeze([
+  { name: "status", values: ["complete", "partial"] },
+  { name: "degradedBranches[]", values: ["direct_folder_name", "file_evidence"] },
+  { name: "matchStrength", values: ["exact", "strong", "supporting"] },
+  {
+    name: "reasonCodes[]",
+    values: [
+      "exact_folder_name",
+      "direct_folder_name",
+      "path_token_match",
+      "child_filename",
+      "child_content",
+    ],
+  },
+  { name: "breadcrumb[].sessionType", values: ["creative_project", "session"] },
+  { name: "branchStatus[].branch", values: ["direct_folder_name", "file_evidence"] },
+  { name: "branchStatus[].status", values: ["ok", "timeout", "error", "skipped"] },
+]);
+
+function validateFolderResponseFieldContract(table, errors) {
+  addError(errors, table !== undefined, "folder-management: folder_find is missing its response field contract");
+  if (!table) return;
+
+  const actual = table.rows.map((row) => ({
+    object: normalizeCell(row.Object ?? ""),
+    name: normalizeCell(row.Field ?? ""),
+    type: normalizeCell(row.Type ?? ""),
+  }));
+  addError(
+    errors,
+    actual.length === FOLDER_RESPONSE_FIELDS.length &&
+      actual.every((row, index) =>
+        row.object === FOLDER_RESPONSE_FIELDS[index].object &&
+        row.name === FOLDER_RESPONSE_FIELDS[index].name
+      ),
+    "folder-management: folder_find response fields must exactly match the documented schema in order",
+  );
+
+  for (const contract of FOLDER_RESPONSE_FIELDS) {
+    const row = actual.find(
+      ({ object, name }) => object === contract.object && name === contract.name,
+    );
+    const path = `${contract.object}.${contract.name}`;
+    addError(errors, row !== undefined, `folder-management: folder_find response is missing ${path}`);
+    if (!row) continue;
+    addError(
+      errors,
+      row.type === contract.type,
+      `folder-management: folder_find ${path} type must be ${contract.type}`,
+    );
+  }
+}
+
+function validateFolderResponseEnumContract(table, errors) {
+  addError(errors, table !== undefined, "folder-management: folder_find is missing its closed response enums");
+  if (!table) return;
+
+  const actualNames = table.rows.map((row) => normalizeCell(row.Field ?? ""));
+  addError(
+    errors,
+    actualNames.length === FOLDER_RESPONSE_ENUMS.length &&
+      actualNames.every((name, index) => name === FOLDER_RESPONSE_ENUMS[index].name),
+    `folder-management: folder_find enum fields must be exactly ${FOLDER_RESPONSE_ENUMS.map(({ name }) => name).join("|")} in order`,
+  );
+
+  for (const contract of FOLDER_RESPONSE_ENUMS) {
+    const row = table.rows.find((candidate) => normalizeCell(candidate.Field ?? "") === contract.name);
+    addError(errors, row !== undefined, `folder-management: folder_find enum is missing ${contract.name}`);
+    if (!row) continue;
+    addError(
+      errors,
+      sameSet([...new Set(codeValues(row["Exact values"] ?? ""))], contract.values),
+      `folder-management: folder_find ${contract.name} must be exactly ${contract.values.join("|")}`,
+    );
+  }
+}
+
+function isPlainObject(value) {
+  return value !== null && typeof value === "object" && !Array.isArray(value);
+}
+
+function hasExactKeys(value, expected) {
+  return isPlainObject(value) && sameSet(Object.keys(value), expected);
+}
+
+function isNonNegativeInteger(value) {
+  return Number.isInteger(value) && value >= 0;
+}
+
+function validateFolderResponseExample(section, errors) {
+  const block = section.match(/```json\s*\n([\s\S]*?)\n```/);
+  addError(errors, block !== null, "folder-management: folder_find is missing its JSON response example");
+  if (!block) return;
+
+  let response;
+  try {
+    response = JSON.parse(block[1]);
+  } catch {
+    errors.push("folder-management: folder_find JSON response example must parse");
+    return;
+  }
+
+  const envelopeKeys = ["data", "count", "status", "partial", "degradedBranches", "branchStatus"];
+  addError(errors, hasExactKeys(response, envelopeKeys), "folder-management: folder_find example envelope fields must be exact");
+  addError(errors, Array.isArray(response?.data), "folder-management: folder_find example data must be an array");
+  addError(errors, isNonNegativeInteger(response?.count), "folder-management: folder_find example count must be a non-negative integer");
+  addError(errors, ["complete", "partial"].includes(response?.status), "folder-management: folder_find example status must be complete|partial");
+  addError(errors, typeof response?.partial === "boolean", "folder-management: folder_find example partial must be boolean");
+  addError(errors, Array.isArray(response?.degradedBranches), "folder-management: folder_find example degradedBranches must be an array");
+  addError(
+    errors,
+    Array.isArray(response?.degradedBranches) &&
+      response.degradedBranches.every((branch) => ["direct_folder_name", "file_evidence"].includes(branch)),
+    "folder-management: folder_find example degradedBranches values must be direct_folder_name|file_evidence",
+  );
+
+  const results = Array.isArray(response?.data) ? response.data : [];
+  addError(errors, results.length > 0, "folder-management: folder_find example must include one typed result");
+  for (const result of results) {
+    addError(
+      errors,
+      hasExactKeys(result, ["folder", "project", "breadcrumb", "matchStrength", "reasonCodes", "evidence"]),
+      "folder-management: folder_find example result fields must be exact",
+    );
+    for (const field of ["folder", "project"]) {
+      const value = result?.[field];
+      addError(errors, hasExactKeys(value, ["id", "name"]), `folder-management: folder_find example ${field} fields must be id|name`);
+      addError(errors, typeof value?.id === "string", `folder-management: folder_find example ${field}.id must be string`);
+      addError(errors, typeof value?.name === "string", `folder-management: folder_find example ${field}.name must be string`);
+    }
+    addError(errors, Array.isArray(result?.breadcrumb), "folder-management: folder_find example breadcrumb must be an array");
+    for (const entry of Array.isArray(result?.breadcrumb) ? result.breadcrumb : []) {
+      addError(errors, hasExactKeys(entry, ["id", "name", "sessionType"]), "folder-management: folder_find example breadcrumb fields must be id|name|sessionType");
+      addError(errors, typeof entry?.id === "string", "folder-management: folder_find example breadcrumb.id must be string");
+      addError(errors, typeof entry?.name === "string", "folder-management: folder_find example breadcrumb.name must be string");
+      addError(
+        errors,
+        ["creative_project", "session"].includes(entry?.sessionType),
+        "folder-management: folder_find example breadcrumb.sessionType must be creative_project|session",
+      );
+    }
+    addError(errors, ["exact", "strong", "supporting"].includes(result?.matchStrength), "folder-management: folder_find example matchStrength must be exact|strong|supporting");
+    addError(errors, Array.isArray(result?.reasonCodes), "folder-management: folder_find example reasonCodes must be an array");
+    const reasons = ["exact_folder_name", "direct_folder_name", "path_token_match", "child_filename", "child_content"];
+    addError(
+      errors,
+      Array.isArray(result?.reasonCodes) && result.reasonCodes.every((reason) => reasons.includes(reason)),
+      "folder-management: folder_find example reasonCodes contain an undocumented value",
+    );
+    const evidenceFields = ["directMatchCount", "childFileCount", "childFilenameCount", "childContentCount"];
+    addError(errors, hasExactKeys(result?.evidence, evidenceFields), "folder-management: folder_find example evidence fields must be exact");
+    for (const field of evidenceFields) {
+      addError(
+        errors,
+        isNonNegativeInteger(result?.evidence?.[field]),
+        `folder-management: folder_find example evidence.${field} must be a non-negative integer`,
+      );
+    }
+  }
+
+  addError(errors, Array.isArray(response?.branchStatus), "folder-management: folder_find example branchStatus must be an array");
+  const branchStates = Array.isArray(response?.branchStatus) ? response.branchStatus : [];
+  for (const state of branchStates) {
+    addError(errors, hasExactKeys(state, ["branch", "status"]), "folder-management: folder_find example branchStatus fields must be branch|status");
+    addError(
+      errors,
+      ["direct_folder_name", "file_evidence"].includes(state?.branch),
+      "folder-management: folder_find example branch must be direct_folder_name|file_evidence",
+    );
+    addError(
+      errors,
+      ["ok", "timeout", "error", "skipped"].includes(state?.status),
+      "folder-management: folder_find example branch status must be ok|timeout|error|skipped",
+    );
+  }
+  addError(
+    errors,
+    sameSet(branchStates.map((state) => state?.branch), ["direct_folder_name", "file_evidence"]),
+    "folder-management: folder_find example must include each branch exactly once",
+  );
+}
+
+function validateSearchContract(markdown, errors) {
+  const section = getSection(markdown, "GET /v1/search");
+  addError(errors, section !== null, "file-management: missing GET /v1/search section");
+  if (!section) return;
+
+  const table = findParameterTable(section, ["Parameter", "Type", "Required", "Default", "Description"]);
+  addError(errors, table !== undefined, "file-management: search query table must include a Required column");
+  if (!table) return;
+  validateExactParameterContract(table, SEARCH_PARAMETERS, "file-management: search", errors);
+
+  const q = findParameterRow(table, "q");
+  addError(errors, normalizeCell(q?.Required ?? "") === "Yes", "file-management: q must be explicitly required");
+  addError(
+    errors,
+    sameSet(numericRanges(q?.Description ?? ""), ["1-255"]),
+    "file-management: q must document the exact 1-255 character limit",
+  );
+
+  const type = findParameterRow(table, "type");
+  addError(
+    errors,
+    sameSet(
+      [...new Set(codeValues(type?.Description ?? ""))],
+      ["file", "folder", "project", "asset", "workspace"],
+    ),
+    "file-management: type must be exactly file|folder|project|asset|workspace",
+  );
+
+  const searchIn = findParameterRow(table, "searchIn");
+  addError(errors, normalizeCell(searchIn?.Default ?? "") === "all", "file-management: searchIn default must be all");
+  addError(
+    errors,
+    sameSet([...new Set(codeValues(searchIn?.Description ?? ""))], ["name", "content", "all"]),
+    "file-management: searchIn must be exactly name|content|all",
+  );
+
+  const matchMode = findParameterRow(table, "matchMode");
+  addError(errors, normalizeCell(matchMode?.Default ?? "") === "any", "file-management: matchMode default must be any");
+  addError(
+    errors,
+    sameSet([...new Set(codeValues(matchMode?.Description ?? ""))], ["any", "all", "phrase"]),
+    "file-management: matchMode must be exactly any|all|phrase",
+  );
+
+  const limit = findParameterRow(table, "limit");
+  addError(errors, normalizeCell(limit?.Default ?? "") === "50", "file-management: search limit default must be 50");
+  addError(
+    errors,
+    sameSet(numericRanges(limit?.Description ?? ""), ["1-200"]),
+    "file-management: search limit range must be exactly 1-200",
+  );
+
+  const sortBy = findParameterRow(table, "sortBy");
+  addError(errors, normalizeCell(sortBy?.Default ?? "") === "relevance", "file-management: sortBy default must be relevance");
+  addError(
+    errors,
+    sameSet([...new Set(codeValues(sortBy?.Description ?? ""))], ["relevance", "createdAt"]),
+    "file-management: sortBy must be exactly relevance|createdAt",
+  );
+
+  const sortOrder = findParameterRow(table, "sortOrder");
+  addError(errors, normalizeCell(sortOrder?.Default ?? "") === "desc", "file-management: sortOrder default must be desc");
+  addError(
+    errors,
+    sameSet(
+      [...new Set(codeValues(sortOrder?.Description ?? "").filter((value) => value !== "sortBy=createdAt"))],
+      ["asc", "desc"],
+    ),
+    "file-management: sortOrder must be exactly asc|desc",
+  );
+
+  addError(
+    errors,
+    section.includes('{ "data": [...], "count": N, "cursor": "<opaque token or null>" }'),
+    "file-management: search response must be grouped as {data,count,cursor}",
+  );
+  const fieldTable = findFieldTable(section, "sourceType");
+  validateExactFieldContract(fieldTable, SEARCH_ITEM_FIELDS, "file-management: grouped search item", errors);
+  for (const field of ["container", "project", "breadcrumb"]) {
+    addError(
+      errors,
+      findParameterRow(fieldTable, field) !== undefined,
+      `file-management: grouped search context is missing ${field}`,
+    );
+  }
+
+  const sourceType = findParameterRow(fieldTable, "sourceType");
+  addError(
+    errors,
+    sameSet([...new Set(codeValues(sourceType?.Description ?? ""))], ["file", "folder", "project", "asset"]),
+    "file-management: grouped search sourceType must be exactly file|folder|project|asset",
+  );
+
+  const matchTable = findFieldTable(section, "rowKind");
+  validateExactFieldContract(matchTable, SEARCH_MATCH_FIELDS, "file-management: grouped search match", errors);
+  const rowKind = findParameterRow(matchTable, "rowKind");
+  addError(
+    errors,
+    sameSet([...new Set(codeValues(rowKind?.Description ?? ""))], ["name", "body", "annotation"]),
+    "file-management: match rowKind must be exactly name|body|annotation",
+  );
+
+  const shapeTable = findExactTable(section, ["Object", "Exact shape"]);
+  validateExactShapeContract(shapeTable, SEARCH_CONTEXT_SHAPES, "file-management: canonical context", errors);
+
+  addError(
+    errors,
+    normalizeCell(findParameterRow(fieldTable, "sourceCreatedAt")?.Type ?? "") === "datetime | null",
+    "file-management: sourceCreatedAt must be nullable",
+  );
+  const container = findParameterRow(fieldTable, "container");
+  addError(
+    errors,
+    normalizeCell(container?.Type ?? "") === "object | null",
+    "file-management: container must be a nullable object",
+  );
+  addError(
+    errors,
+    sameSet(
+      [...new Set(codeValues(container?.Description ?? ""))],
+      ["id", "name", "kind", "folder", "project"],
+    ),
+    "file-management: container must document id|name|kind and folder|project kinds",
+  );
+
+  addError(
+    errors,
+    /File and folder results always carry a complete canonical\s+context unit/.test(section),
+    "file-management: file/folder context must be complete",
+  );
+  addError(
+    errors,
+    /hits whose current lineage is missing, deleted, malformed, stale,\s+or unauthorized are omitted/.test(section),
+    "file-management: unverifiable file/folder hits must be omitted",
+  );
+  addError(
+    errors,
+    /keys are required on every search\s+item but nullable as one all-or-nothing context unit/.test(section),
+    "file-management: context must be documented as required-nullable and all-or-nothing",
+  );
+  addError(
+    errors,
+    /For a file, `sessionId` is its current canonical containing folder or\s+project/.test(section) &&
+      /For a folder or project result, `sessionId` identifies the matched\s+session itself; determine parentage only from `container` and `breadcrumb`/.test(section),
+    "file-management: sessionId semantics must distinguish files from sessions",
+  );
+  addError(
+    errors,
+    section.includes("/api/v1/search?q=hero&type=file&cursor=<token>"),
+    "file-management: next-page example must replay type=file",
+  );
+  addError(
+    errors,
+    /Replay the original `q` and every corpus-shaping filter/.test(section) &&
+      /malformed or mismatched bound cursor returns 422/.test(section),
+    "file-management: cursor replay and mismatch semantics are missing",
+  );
+  addError(
+    errors,
+    /Pre-`matchMode` legacy cursors are treated as unbound `any`-mode compatibility\s+tokens/.test(section) &&
+      /regardless of a re-sent `matchMode`/.test(section),
+    "file-management: legacy cursor compatibility must be explicit",
+  );
+  addError(
+    errors,
+    sameSet(tableCodes(findStatusTable(section)), ["200", "400", "401", "403", "422", "500", "503"]),
+    "file-management: search status codes must be exactly 200|400|401|403|422|500|503",
+  );
+  addError(
+    errors,
+    /search_context_unavailable/.test(section),
+    "file-management: search 503 must identify search_context_unavailable",
+  );
+}
+
+function validateFolderFindContract(markdown, errors) {
+  const section = getSection(markdown, "GET /v1/search/folders");
+  addError(errors, section !== null, "folder-management: missing GET /v1/search/folders section");
+  if (!section) return;
+
+  const table = findParameterTable(section, ["Parameter", "Type", "Required", "Default", "Description"]);
+  addError(errors, table !== undefined, "folder-management: folder_find query table must include required/default columns");
+  if (!table) return;
+  validateExactParameterContract(table, FOLDER_FIND_PARAMETERS, "folder-management: folder_find", errors);
+
+  const q = findParameterRow(table, "q");
+  addError(errors, normalizeCell(q?.Required ?? "") === "Yes", "folder-management: folder_find q must be required");
+  addError(errors, /Nonblank/.test(q?.Description ?? ""), "folder-management: folder_find q must reject blank input");
+  addError(
+    errors,
+    sameSet(numericRanges(q?.Description ?? ""), ["1-255"]),
+    "folder-management: folder_find q range must be exactly 1-255",
+  );
+
+  for (const parameter of ["workspaceId", "projectId"]) {
+    const row = findParameterRow(table, parameter);
+    addError(errors, row !== undefined, `folder-management: folder_find is missing ${parameter}`);
+    addError(errors, normalizeCell(row?.Required ?? "") === "No", `folder-management: folder_find ${parameter} must be optional`);
+  }
+
+  const limit = findParameterRow(table, "limit");
+  addError(errors, normalizeCell(limit?.Default ?? "") === "5", "folder-management: folder_find limit default must be 5");
+  addError(
+    errors,
+    sameSet(numericRanges(limit?.Description ?? ""), ["1-10"]),
+    "folder-management: folder_find limit range must be exactly 1-10",
+  );
+
+  validateFolderResponseFieldContract(findExactTable(section, ["Object", "Field", "Type"]), errors);
+  validateFolderResponseEnumContract(findExactTable(section, ["Field", "Exact values"]), errors);
+  validateFolderResponseExample(section, errors);
+
+  for (const field of ["data", "count", "status", "partial", "degradedBranches", "branchStatus"]) {
+    addError(errors, section.includes(`"${field}"`), `folder-management: folder_find response is missing ${field}`);
+  }
+  for (const field of ["folder", "project", "breadcrumb", "matchStrength", "reasonCodes", "evidence"]) {
+    addError(errors, section.includes(`"${field}"`), `folder-management: folder_find result is missing ${field}`);
+  }
+  addError(
+    errors,
+    /`matchStrength` is exactly `exact`, `strong`, or `supporting`/.test(section),
+    "folder-management: folder_find matchStrength must be exact|strong|supporting",
+  );
+  for (const reason of [
+    "exact_folder_name",
+    "direct_folder_name",
+    "path_token_match",
+    "child_filename",
+    "child_content",
+  ]) {
+    addError(errors, section.includes(`\`${reason}\``), `folder-management: folder_find reasonCodes is missing ${reason}`);
+  }
+  for (const field of [
+    "directMatchCount",
+    "childFileCount",
+    "childFilenameCount",
+    "childContentCount",
+  ]) {
+    addError(errors, section.includes(`"${field}"`), `folder-management: folder_find evidence is missing ${field}`);
+  }
+
+  const responseStart = section.indexOf("```json");
+  const responseEnd = responseStart === -1 ? -1 : section.indexOf("```", responseStart + 7);
+  const responseExample = responseEnd === -1 ? "" : section.slice(responseStart, responseEnd);
+  for (const forbidden of ["fileName", "fileId", "snippets", "body", "rawScore", "webUrl"]) {
+    addError(
+      errors,
+      !responseExample.includes(`"${forbidden}"`),
+      `folder-management: folder_find response must not expose ${forbidden}`,
+    );
+  }
+  addError(errors, /Evidence is count-only/.test(section), "folder-management: folder_find evidence must be count-only");
+  addError(
+    errors,
+    /CheehooData does not return matching child file names,\s+file IDs, snippets, bodies, raw Atlas scores, or navigation URLs/.test(section),
+    "folder-management: folder_find must document its content-free boundary",
+  );
+  addError(errors, section.includes("https://studio.spuree.com/folders/{folderId}"), "folder-management: folder_find must construct canonical folder URLs locally");
+  addError(errors, section.includes("https://studio.spuree.com/projects/{projectId}"), "folder-management: folder_find must construct canonical project URLs locally");
+  addError(errors, section.includes('`status: "partial"`'), "folder-management: folder_find must document partial status");
+  addError(errors, section.includes("eight-second ceiling"), "folder-management: folder_find must document the eight-second ceiling");
+  addError(
+    errors,
+    /`branchStatus\[\]\.status` is exactly `ok`, `timeout`,\s+`error`, or `skipped`/.test(section),
+    "folder-management: branch status must be exactly ok|timeout|error|skipped",
+  );
+  addError(
+    errors,
+    sameSet(tableCodes(findStatusTable(section)), ["200", "400", "401", "403", "422", "500", "503"]),
+    "folder-management: folder_find status codes must be exactly 200|400|401|403|422|500|503",
+  );
+  addError(
+    errors,
+    /no safe high-signal term/.test(section),
+    "folder-management: folder_find 400 must document unsafe low-signal queries",
+  );
+  addError(
+    errors,
+    /Shared request deadline expires/.test(section),
+    "folder-management: folder_find 503 must include the shared request deadline",
+  );
+}
+
+function validateFolderListContract(markdown, errors) {
+  const section = getSection(markdown, "GET /v1/folders");
+  addError(errors, section !== null, "folder-management: missing GET /v1/folders section");
+  if (!section) return;
+
+  const table = findParameterTable(section, ["Parameter", "Type", "Default", "Description"]);
+  addError(errors, table !== undefined, "folder-management: missing GET /v1/folders query table");
+  if (!table) return;
+
+  const expectedDefaults = new Map([
+    ["sortBy", "createdAt"],
+    ["sortOrder", "desc"],
+    ["limit", "50"],
+    ["offset", "0"],
+  ]);
+  for (const [parameter, expected] of expectedDefaults) {
+    const row = findParameterRow(table, parameter);
+    addError(
+      errors,
+      normalizeCell(row?.Default ?? "") === expected,
+      `folder-management: ${parameter} default must be ${expected}`,
+    );
+  }
+  for (const parameter of ["workspaceId", "projectId"]) {
+    addError(errors, findParameterRow(table, parameter) !== undefined, `folder-management: missing ${parameter} folder filter`);
+  }
+
+  addError(errors, /1-200/.test(findParameterRow(table, "limit")?.Description ?? ""), "folder-management: folder limit range must be 1-200");
+  for (const field of ["folders", "total", "limit", "offset"]) {
+    addError(errors, section.includes(`"${field}"`), `folder-management: folder response is missing ${field}`);
+  }
+}
+
+function validateChildrenContract(markdown, heading, label, errors) {
+  const section = getSection(markdown, heading);
+  addError(errors, section !== null, `${label}: missing ${heading} section`);
+  if (!section) return;
+
+  addError(errors, section.includes("{ items: [...] }"), `${label}: children response must use {items}`);
+  addError(errors, section.includes('{ "items": [] }'), `${label}: empty children response must be {items:[]}`);
+  addError(errors, !/fall back|legacy/i.test(section), `${label}: children section must not recommend a legacy fallback`);
+  addError(
+    errors,
+    !/\{\s*(sessions|entities|files)\s*:/.test(section),
+    `${label}: children section must not document split top-level arrays`,
+  );
+}
+
+function validateBoundedRecipe(folderMarkdown, errors) {
+  const section = getSection(folderMarkdown, "Find a Named Folder (Bounded Search-First Recipe)");
+  addError(errors, section !== null, "folder-management: missing bounded named-folder recipe");
+  if (!section) return;
+
+  const direct = "GET /v1/search?q={encodedQuery}&type=folder&searchIn=name&matchMode=all&limit=50";
+  const evidence = "GET /v1/search?q={encodedQuery}&type=file&searchIn=all&matchMode=all&limit=50";
+  const oneCall = "GET /v1/search/folders?q={encodedNaturalLanguageQuery}&limit=5";
+  addError(errors, count(section, oneCall) === 1, "folder-management: recipe must prefer exactly one folder_find request");
+  addError(errors, count(section, direct) === 1, "folder-management: recipe must make one direct folder-name search");
+  addError(errors, count(section, evidence) === 1, "folder-management: recipe must define exactly one file-evidence fallback");
+  addError(errors, section.indexOf(oneCall) < section.indexOf(direct), "folder-management: folder_find must precede compatibility searches");
+  addError(errors, /Compatibility fallback only/.test(section), "folder-management: generic searches must be compatibility-only");
+  addError(errors, /Preserve explicit partial status/.test(section), "folder-management: recipe must preserve folder_find degradation status");
+  addError(errors, section.indexOf(direct) < section.indexOf(evidence), "folder-management: direct folder search must precede file evidence");
+  addError(errors, /Group the returned file\s+results by their containing `sessionId`/.test(section), "folder-management: file evidence must be grouped by sessionId");
+  addError(errors, /likely leaf-folder stem/.test(section), "folder-management: recipe must separate the leaf name from hierarchy qualifiers");
+  addError(
+    errors,
+    /search for `Phase`/.test(section) &&
+      /requested\s+labels `0` and `A`/.test(section) &&
+      /use `PLOCAN` \/ `Works` as hierarchy qualifiers/.test(section) &&
+      /do not\s+treat `Works` as the leaf/.test(section),
+    "folder-management: PLOCAN fallback must target Phase 0 and Phase A beneath PLOCAN / Works",
+  );
+  addError(errors, /Do not\s+send\s+request verbs or the entire\s+natural-language sentence/.test(section), "folder-management: recipe must not submit the whole request as the folder query");
+  addError(errors, /single fallback/.test(section), "folder-management: recipe must stop after one fallback");
+  addError(errors, /do not enumerate projects/i.test(section), "folder-management: recipe must prohibit project enumeration");
+  addError(errors, /recursively traverse folders/i.test(section), "folder-management: recipe must prohibit recursive traversal");
+  addError(errors, !/GET \/v1\/(projects|sessions)\/[^\n]*\/children/.test(section), "folder-management: recipe must not call child endpoints");
+}
+
+function validateCanonicalUrls(documents, errors) {
+  for (const [label, markdown] of Object.entries(documents)) {
+    addError(errors, !/https:\/\/studio\.spuree\.com\/file\//.test(markdown), `${label}: singular /file Studio URL is forbidden`);
+    addError(
+      errors,
+      !/\/projects\/\{[^}]+\}\/folders\//.test(markdown),
+      `${label}: multi-segment project/folder Studio URL is forbidden`,
+    );
+    addError(
+      errors,
+      !/(?:\.\.\.)?\/folders\/\{[^}]+\}\/\{[^}]+\}/.test(markdown),
+      `${label}: nested multi-ID folder Studio URL is forbidden`,
+    );
+    addError(errors, !/(?:[?&]|\s)type=session(?:[&\s`"']|$)/.test(markdown), `${label}: executable type=session search is forbidden`);
+  }
+
+  addError(errors, documents.folder.includes("https://studio.spuree.com/folders/{folderId}"), "folder-management: canonical folder URL is missing");
+  addError(errors, documents.file.includes("https://studio.spuree.com/files/{fileId}"), "file-management: canonical file URL is missing");
+}
+
+export function validateFolderDiscoveryContract(documents) {
+  const errors = [];
+  for (const key of Object.keys(SKILL_FILES)) {
+    addError(errors, typeof documents[key] === "string", `missing skill document: ${key}`);
+  }
+  if (errors.length > 0) return errors.sort();
+
+  for (const key of CONTRACT_SKILLS) {
+    addError(errors, typeof documents[key] === "string", `missing contract skill document: ${key}`);
+  }
+  if (errors.length > 0) return errors.sort();
+
+  validateSearchContract(documents.file, errors);
+  validateFolderFindContract(documents.folder, errors);
+  validateFolderListContract(documents.folder, errors);
+  validateChildrenContract(documents.folder, "GET /v1/sessions/{sessionId}/children", "folder-management", errors);
+  validateChildrenContract(documents.project, "GET /v1/projects/{projectId}/children", "project-management", errors);
+  validateBoundedRecipe(documents.folder, errors);
+  validateCanonicalUrls(documents, errors);
+
+  addError(
+    errors,
+    documents.project.includes("type=project&searchIn=name&matchMode=all"),
+    "project-management: named project discovery must be search-first",
+  );
+  addError(
+    errors,
+    /prefer the one-call\s+`folder_find` workflow/.test(documents.gettingStarted),
+    "getting-started: walkthrough must prefer folder_find",
+  );
+  addError(
+    errors,
+    /fixed two-search compatibility\s+fallback/.test(documents.gettingStarted),
+    "getting-started: walkthrough must bound the compatibility fallback",
+  );
+  addError(errors, !documents.project.includes("browse recursively"), "project-management: recursive discovery instruction is forbidden");
+  addError(errors, !documents.folder.includes("Repeat** to go deeper"), "folder-management: unbounded repeat instruction is forbidden");
+
+  return errors.sort();
+}
+
+export async function loadSkillDocuments(root = DEFAULT_ROOT) {
+  return Object.fromEntries(
+    await Promise.all(
+      Object.entries(SKILL_FILES).map(async ([key, relativePath]) => [
+        key,
+        await readFile(path.join(root, relativePath), "utf8"),
+      ]),
+    ),
+  );
+}
+
+function parseRoot(argv) {
+  const index = argv.indexOf("--root");
+  if (index === -1) return DEFAULT_ROOT;
+  if (!argv[index + 1]) throw new Error("--root requires a path");
+  return path.resolve(argv[index + 1]);
+}
+
+export async function main(argv = process.argv.slice(2)) {
+  const root = parseRoot(argv);
+  const documents = await loadSkillDocuments(root);
+  const errors = validateFolderDiscoveryContract(documents);
+
+  if (errors.length > 0) {
+    console.error("Folder-discovery contract check failed:");
+    for (const error of errors) console.error(`- ${error}`);
+    return 1;
+  }
+
+  console.log(`Folder-discovery contract check passed (${Object.keys(SKILL_FILES).length} skills).`);
+  return 0;
+}
+
+if (process.argv[1] && path.resolve(process.argv[1]) === SCRIPT_PATH) {
+  process.exitCode = await main();
+}

--- a/scripts/check-folder-discovery-contract.mjs
+++ b/scripts/check-folder-discovery-contract.mjs
@@ -900,6 +900,13 @@ function validateBoundedRecipe(folderMarkdown, errors) {
   );
   addError(
     errors,
+    /Nested descendant files are a known blind spot/.test(section) &&
+      /Treat zero direct-file evidence as inconclusive/.test(section) &&
+      /do not traverse descendants\s+to compensate/.test(section),
+    "folder-management: nested-file evidence limitation must be explicit",
+  );
+  addError(
+    errors,
     /If direct search\s+returned no folder candidates, stop/.test(section) &&
       /file evidence cannot establish a folder identity by itself/.test(section),
     "folder-management: file evidence must not create candidates after an empty direct search",
@@ -919,6 +926,33 @@ function validateBoundedRecipe(folderMarkdown, errors) {
   addError(errors, /do not\s+enumerate projects/i.test(section), "folder-management: recipe must prohibit project enumeration");
   addError(errors, /recursively traverse folders/i.test(section), "folder-management: recipe must prohibit recursive traversal");
   addError(errors, !/GET \/v1\/(projects|sessions)\/[^\n]*\/children/.test(section), "folder-management: recipe must not call child endpoints");
+}
+
+function validateProjectDiscoveryRecipe(projectMarkdown, errors) {
+  const section = getSection(projectMarkdown, "Agent Workflow: Project Discovery");
+  addError(errors, section !== null, "project-management: missing named-project discovery recipe");
+  if (!section) return;
+
+  const request = "GET /v1/search?q={encodedQuery}&type=project&searchIn=name&limit=50";
+  addError(errors, count(section, request) === 1, "project-management: named project discovery must be search-first");
+  addError(
+    errors,
+    !section.includes("matchMode="),
+    "project-management: compatibility-safe discovery must not require matchMode",
+  );
+  addError(
+    errors,
+    /compatibility-safe recipe intentionally omits\s+`matchMode`/.test(section) &&
+      /deployment that predates that\s+parameter/.test(section),
+    "project-management: matchMode compatibility reason must be explicit",
+  );
+  addError(
+    errors,
+    /exact case-insensitive `sessionName` match first/.test(section) &&
+      /normalized full-name match/.test(section) &&
+      /ask the user to choose if the\s+result remains ambiguous/.test(section),
+    "project-management: compatibility results need deterministic disambiguation",
+  );
 }
 
 function validateCanonicalUrls(documents, errors) {
@@ -959,13 +993,8 @@ export function validateFolderDiscoveryContract(documents) {
   validateChildrenContract(documents.folder, "GET /v1/sessions/{sessionId}/children", "folder-management", errors);
   validateChildrenContract(documents.project, "GET /v1/projects/{projectId}/children", "project-management", errors);
   validateBoundedRecipe(documents.folder, errors);
+  validateProjectDiscoveryRecipe(documents.project, errors);
   validateCanonicalUrls(documents, errors);
-
-  addError(
-    errors,
-    documents.project.includes("type=project&searchIn=name&matchMode=all"),
-    "project-management: named project discovery must be search-first",
-  );
   addError(
     errors,
     /prefer the one-call\s+`folder_find` workflow/.test(documents.gettingStarted),

--- a/scripts/check-folder-discovery-contract.mjs
+++ b/scripts/check-folder-discovery-contract.mjs
@@ -583,6 +583,13 @@ function validateSearchContract(markdown, errors) {
     section.includes('{ "data": [...], "count": N, "cursor": "<opaque token or null>" }'),
     "file-management: search response must be grouped as {data,count,cursor}",
   );
+  addError(
+    errors,
+    /Continue pagination whenever `cursor` is non-null, even when `count` is smaller\s+than the requested `limit`/.test(
+      section,
+    ),
+    "file-management: short-page cursor continuation semantics are missing",
+  );
   const fieldTable = findFieldTable(section, "sourceType");
   validateExactFieldContract(fieldTable, SEARCH_ITEM_FIELDS, "file-management: grouped search item", errors);
   for (const field of ["container", "project", "breadcrumb"]) {
@@ -661,7 +668,10 @@ function validateSearchContract(markdown, errors) {
   addError(
     errors,
     /Replay the original `q` and every corpus-shaping filter/.test(section) &&
-      /malformed, tampered, or mismatched bound\s+cursor returns 422/.test(section),
+      /malformed, tampered, or mismatched bound\s+cursor returns 422/.test(section) &&
+      /permission scope changes, discard it and restart from page one with the same\s+query and filters; do not retry the rejected cursor/.test(
+        section,
+      ),
     "file-management: cursor replay and mismatch semantics are missing",
   );
   addError(

--- a/scripts/check-folder-discovery-contract.mjs
+++ b/scripts/check-folder-discovery-contract.mjs
@@ -659,14 +659,22 @@ function validateSearchContract(markdown, errors) {
   addError(
     errors,
     /Replay the original `q` and every corpus-shaping filter/.test(section) &&
-      /malformed or mismatched bound cursor returns 422/.test(section),
+      /malformed, tampered, or mismatched bound\s+cursor returns 422/.test(section),
     "file-management: cursor replay and mismatch semantics are missing",
   );
   addError(
     errors,
-    /Pre-`matchMode` legacy cursors are treated as unbound `any`-mode compatibility\s+tokens/.test(section) &&
-      /regardless of a re-sent `matchMode`/.test(section),
-    "file-management: legacy cursor compatibility must be explicit",
+    /Newly issued HMAC-signed `v1` cursors/.test(section) &&
+      /malformed, tampered, or mismatched bound\s+cursor returns 422/.test(section),
+    "file-management: signed cursor integrity semantics are missing",
+  );
+  addError(
+    errors,
+    /Unsigned pre-v1 cursors are treated as unbound `any`-mode compatibility tokens/.test(section) &&
+      /regardless of a re-sent `matchMode`/.test(section) &&
+      /only until \*\*2026-09-07 00:00 UTC\*\*/.test(section) &&
+      /At and after the sunset,\s+every unsigned cursor is rejected/.test(section),
+    "file-management: bounded legacy cursor migration must be explicit",
   );
   addError(
     errors,

--- a/scripts/check-folder-discovery-contract.mjs
+++ b/scripts/check-folder-discovery-contract.mjs
@@ -783,8 +783,18 @@ function validateFolderFindContract(markdown, errors) {
   );
   addError(
     errors,
-    /Shared request deadline expires/.test(section),
+    /search_query_too_broad/.test(section),
+    "folder-management: folder_find 400 must identify search_query_too_broad",
+  );
+  addError(
+    errors,
+    /shared request deadline expires/i.test(section),
     "folder-management: folder_find 503 must include the shared request deadline",
+  );
+  addError(
+    errors,
+    /folder_discovery_unavailable/.test(section),
+    "folder-management: folder_find 503 must identify folder_discovery_unavailable",
   );
 }
 
@@ -841,29 +851,64 @@ function validateBoundedRecipe(folderMarkdown, errors) {
   addError(errors, section !== null, "folder-management: missing bounded named-folder recipe");
   if (!section) return;
 
-  const direct = "GET /v1/search?q={encodedQuery}&type=folder&searchIn=name&matchMode=all&limit=50";
-  const evidence = "GET /v1/search?q={encodedQuery}&type=file&searchIn=all&matchMode=all&limit=50";
+  const direct = "GET /v1/search?q={encodedQuery}&type=folder&searchIn=name&limit=50";
+  const evidence = "GET /v1/search?q={encodedQuery}&type=file&searchIn=all&limit=50";
   const oneCall = "GET /v1/search/folders?q={encodedNaturalLanguageQuery}&limit=5";
   addError(errors, count(section, oneCall) === 1, "folder-management: recipe must prefer exactly one folder_find request");
   addError(errors, count(section, direct) === 1, "folder-management: recipe must make one direct folder-name search");
   addError(errors, count(section, evidence) === 1, "folder-management: recipe must define exactly one file-evidence fallback");
   addError(errors, section.indexOf(oneCall) < section.indexOf(direct), "folder-management: folder_find must precede compatibility searches");
   addError(errors, /Compatibility fallback only/.test(section), "folder-management: generic searches must be compatibility-only");
+  addError(
+    errors,
+    /tool registry does not contain `folder_find`/.test(section) &&
+      /returns 404 or 405/.test(section),
+    "folder-management: compatibility fallback must require confirmed endpoint absence",
+  );
+  addError(
+    errors,
+    /Do not fall back after a 400, 401, 403,\s+422, 500, or 503 response, a timeout, or a network failure/.test(section),
+    "folder-management: compatibility fallback must not mask API or transport failures",
+  );
+  addError(
+    errors,
+    /old enough to lack `folder_find` also lacks `matchMode`/.test(section) &&
+      /may\s+not return canonical `container`, `project`, or `breadcrumb` context/.test(section),
+    "folder-management: legacy generic-search limitations must be explicit",
+  );
+  addError(
+    errors,
+    !section.includes("matchMode="),
+    "folder-management: compatibility searches must not require matchMode",
+  );
   addError(errors, /Preserve explicit partial status/.test(section), "folder-management: recipe must preserve folder_find degradation status");
   addError(errors, section.indexOf(direct) < section.indexOf(evidence), "folder-management: direct folder search must precede file evidence");
-  addError(errors, /Group the returned file\s+results by their containing `sessionId`/.test(section), "folder-management: file evidence must be grouped by sessionId");
+  addError(
+    errors,
+    /Build a set of the direct\s+folder results' `sourceId` values/.test(section) &&
+      /Count a file group only when its `sessionId` is in\s+that direct-folder ID set/.test(section) &&
+      /must never introduce a new folder candidate/.test(section),
+    "folder-management: legacy file evidence must only support proven direct folder IDs",
+  );
+  addError(
+    errors,
+    /If direct search\s+returned no folder candidates, stop/.test(section) &&
+      /file evidence cannot establish a folder identity by itself/.test(section),
+    "folder-management: file evidence must not create candidates after an empty direct search",
+  );
   addError(errors, /likely leaf-folder stem/.test(section), "folder-management: recipe must separate the leaf name from hierarchy qualifiers");
   addError(
     errors,
-    /search for `Phase`/.test(section) &&
+    /search for\s+`Phase`/.test(section) &&
       /requested\s+labels `0` and `A`/.test(section) &&
-      /use `PLOCAN` \/ `Works` as hierarchy qualifiers/.test(section) &&
+      /keep `PLOCAN` \/ `Works`\s+only as user-provided qualifiers/.test(section) &&
+      /Do not claim that a result is beneath\s+`PLOCAN \/ Works` unless the response itself supplies canonical context/.test(section) &&
       /do not\s+treat `Works` as the leaf/.test(section),
-    "folder-management: PLOCAN fallback must target Phase 0 and Phase A beneath PLOCAN / Works",
+    "folder-management: PLOCAN fallback must preserve unverified hierarchy qualifiers",
   );
   addError(errors, /Do not\s+send\s+request verbs or the entire\s+natural-language sentence/.test(section), "folder-management: recipe must not submit the whole request as the folder query");
   addError(errors, /single fallback/.test(section), "folder-management: recipe must stop after one fallback");
-  addError(errors, /do not enumerate projects/i.test(section), "folder-management: recipe must prohibit project enumeration");
+  addError(errors, /do not\s+enumerate projects/i.test(section), "folder-management: recipe must prohibit project enumeration");
   addError(errors, /recursively traverse folders/i.test(section), "folder-management: recipe must prohibit recursive traversal");
   addError(errors, !/GET \/v1\/(projects|sessions)\/[^\n]*\/children/.test(section), "folder-management: recipe must not call child endpoints");
 }
@@ -920,8 +965,15 @@ export function validateFolderDiscoveryContract(documents) {
   );
   addError(
     errors,
-    /fixed two-search compatibility\s+fallback/.test(documents.gettingStarted),
+    /fixed two-search\s+compatibility fallback/.test(documents.gettingStarted),
     "getting-started: walkthrough must bound the compatibility fallback",
+  );
+  addError(
+    errors,
+    /tool registry lacks `folder_find`/.test(documents.gettingStarted) &&
+      /endpoint returns 404 or\s+405/.test(documents.gettingStarted) &&
+      /Do not fall back after another response or transport failure/.test(documents.gettingStarted),
+    "getting-started: compatibility fallback must be absence-only",
   );
   addError(errors, !documents.project.includes("browse recursively"), "project-management: recursive discovery instruction is forbidden");
   addError(errors, !documents.folder.includes("Repeat** to go deeper"), "folder-management: unbounded repeat instruction is forbidden");

--- a/scripts/diagnose-spuree-skill-copies.mjs
+++ b/scripts/diagnose-spuree-skill-copies.mjs
@@ -7,11 +7,15 @@ import path from "node:path";
 import { fileURLToPath } from "node:url";
 
 const SCRIPT_PATH = fileURLToPath(import.meta.url);
+const DEFAULT_SOURCE_ROOT = path.resolve(path.dirname(SCRIPT_PATH), "..");
 
 export const TARGET_SKILLS = Object.freeze([
+  "authentication",
+  "file-comment",
   "file-management",
   "folder-management",
   "getting-started",
+  "project-invitation",
   "project-management",
 ]);
 
@@ -176,20 +180,33 @@ function uniqueLocations(locations) {
   });
 }
 
-async function candidateLocations({ cwd, home, codexHome }) {
-  const locations = [];
-  const repositoryRoot = await findRepositoryRoot(cwd);
-  if (repositoryRoot) {
-    locations.push({ root: repositoryRoot, kind: "repository" });
+function ancestorsThrough(start, boundary) {
+  const resolvedBoundary = path.resolve(boundary);
+  const result = [];
+  for (const directory of ancestors(start)) {
+    result.push(directory);
+    if (directory === resolvedBoundary) break;
   }
+  return result;
+}
 
-  for (const directory of ancestors(cwd)) {
+async function candidateLocations({ target, sourceRoot, home, codexHome, hermesHome }) {
+  const locations = [{ root: sourceRoot, kind: "source-reference" }];
+  const repositoryRoot = await findRepositoryRoot(target);
+  const projectBoundary = repositoryRoot ?? path.resolve(target);
+
+  for (const directory of ancestorsThrough(target, projectBoundary)) {
     locations.push({ root: path.join(directory, ".agents", "skills"), kind: "project-agents" });
     locations.push({ root: path.join(directory, ".codex", "skills"), kind: "project-codex" });
+    locations.push({ root: path.join(directory, ".claude", "skills"), kind: "project-claude" });
+    locations.push({ root: path.join(directory, "skills"), kind: "project-workspace" });
   }
 
   locations.push({ root: path.join(home, ".agents", "skills"), kind: "user-agents" });
   locations.push({ root: path.join(codexHome, "skills"), kind: "user-codex" });
+  locations.push({ root: path.join(home, ".claude", "skills"), kind: "user-claude" });
+  locations.push({ root: path.join(home, ".openclaw", "skills"), kind: "user-openclaw" });
+  locations.push({ root: path.join(hermesHome, "skills"), kind: "user-hermes" });
 
   const cacheRoot = path.join(codexHome, "plugins", "cache");
   for (const root of await findPluginSkillRoots(cacheRoot)) {
@@ -242,12 +259,24 @@ async function inspectCopy(skill, location, order) {
   };
 }
 
-export async function discoverSkillCopies({
-  cwd = process.cwd(),
-  home = os.homedir(),
-  codexHome = process.env.CODEX_HOME || path.join(home, ".codex"),
-} = {}) {
-  const locations = await candidateLocations({ cwd, home, codexHome });
+export async function discoverSkillCopies(options = {}) {
+  const home = path.resolve(options.home ?? os.homedir());
+  const target = path.resolve(options.target ?? options.cwd ?? process.cwd());
+  const sourceRoot = path.resolve(options.sourceRoot ?? DEFAULT_SOURCE_ROOT);
+  const codexHome = path.resolve(
+    options.codexHome ?? process.env.CODEX_HOME ?? path.join(home, ".codex"),
+  );
+  const defaultHermesHome = process.platform === "win32" && process.env.LOCALAPPDATA
+    ? path.join(process.env.LOCALAPPDATA, "hermes")
+    : path.join(home, ".hermes");
+  const hermesHome = path.resolve(options.hermesHome ?? defaultHermesHome);
+  const locations = await candidateLocations({
+    target,
+    sourceRoot,
+    home,
+    codexHome,
+    hermesHome,
+  });
   const copies = [];
 
   for (const skill of TARGET_SKILLS) {
@@ -267,27 +296,36 @@ export async function discoverSkillCopies({
     left.path.localeCompare(right.path),
   );
 
-  const duplicates = TARGET_SKILLS.map((skill) => {
-    const matches = copies.filter(
-      (copy) => copy.skill === skill && copy.location !== "repository",
-    );
-    return {
-      skill,
-      installedCopies: matches.length,
-      distinctHashes: new Set(matches.map((copy) => copy.sha256)).size,
-      paths: matches.map((copy) => copy.path),
-    };
-  }).filter((entry) => entry.installedCopies > 1);
+  const installedOrCached = copies.filter(
+    (copy) => copy.location !== "source-reference",
+  );
+  const duplicates = [...new Set(installedOrCached.map((copy) => copy.exposedName))]
+    .sort()
+    .map((exposedName) => {
+      const matches = installedOrCached.filter(
+        (copy) => copy.exposedName === exposedName,
+      );
+      return {
+        skill: matches[0]?.skill ?? exposedName,
+        exposedName,
+        installedCopies: matches.length,
+        distinctHashes: new Set(matches.map((copy) => copy.sha256)).size,
+        paths: matches.map((copy) => copy.path),
+      };
+    })
+    .filter((entry) => entry.installedCopies > 1);
 
   return {
-    schemaVersion: 1,
+    schemaVersion: 2,
     readOnly: true,
     resolutionNote:
-      "catalogOrder is deterministic found-copy scan order only; repository entries are references and plugin-cache entries are candidates, while the active client owns runtime skill precedence, so duplicate unprefixed names are ambiguous",
+      "catalogOrder is deterministic found-copy scan order only; source-reference entries never count as installed collisions, duplicate groups use exposedName, plugin-cache entries are candidates, and the active client owns runtime skill precedence",
     roots: {
-      cwd: path.resolve(cwd),
-      home: path.resolve(home),
-      codexHome: path.resolve(codexHome),
+      target,
+      sourceRoot,
+      home,
+      codexHome,
+      hermesHome,
     },
     copies,
     duplicates,
@@ -307,11 +345,11 @@ function printHuman(report) {
 
   for (const skill of TARGET_SKILLS) {
     const copies = report.copies.filter((copy) => copy.skill === skill);
-    const installedOrCached = copies.filter((copy) => copy.location !== "repository");
+    const installedOrCached = copies.filter((copy) => copy.location !== "source-reference");
     const distinct = new Set(copies.map((copy) => copy.sha256)).size;
     console.log(
       `\n${skill}: ${installedOrCached.length} installed/cache candidate(s), ` +
-      `${copies.length - installedOrCached.length} repository reference(s), ` +
+      `${copies.length - installedOrCached.length} source reference(s), ` +
       `${distinct} distinct hash(es)`,
     );
     if (copies.length === 0) {
@@ -329,14 +367,35 @@ function printHuman(report) {
       console.log(`      path=${copy.path}`);
     }
   }
+
+  console.log("\nExposed-name collisions:");
+  if (report.duplicates.length === 0) {
+    console.log("  (none found)");
+  } else {
+    for (const duplicate of report.duplicates) {
+      console.log(
+        `  ${duplicate.exposedName}: ${duplicate.installedCopies} candidate(s), ` +
+        `${duplicate.distinctHashes} distinct hash(es)`,
+      );
+    }
+  }
 }
 
 export async function main(argv = process.argv.slice(2)) {
   const home = readOption(argv, "--home", os.homedir());
+  const legacyTarget = readOption(argv, "--cwd", process.cwd());
   const report = await discoverSkillCopies({
-    cwd: readOption(argv, "--cwd", process.cwd()),
+    target: readOption(argv, "--target", legacyTarget),
+    sourceRoot: readOption(argv, "--source-root", DEFAULT_SOURCE_ROOT),
     home,
     codexHome: readOption(argv, "--codex-home", process.env.CODEX_HOME || path.join(home, ".codex")),
+    hermesHome: readOption(
+      argv,
+      "--hermes-home",
+      process.platform === "win32" && process.env.LOCALAPPDATA
+        ? path.join(process.env.LOCALAPPDATA, "hermes")
+        : path.join(home, ".hermes"),
+    ),
   });
 
   if (argv.includes("--json")) {

--- a/scripts/diagnose-spuree-skill-copies.mjs
+++ b/scripts/diagnose-spuree-skill-copies.mjs
@@ -110,6 +110,18 @@ async function readPluginManifest(skillPath, cacheRoot) {
   return null;
 }
 
+function fallbackPluginNamespace(skillPath, cacheRoot) {
+  const skillsRoot = path.dirname(path.dirname(skillPath));
+  const relativeRoot = path.relative(path.resolve(cacheRoot), skillsRoot)
+    .split(path.sep)
+    .join("/");
+  const identity = createHash("sha256")
+    .update(relativeRoot)
+    .digest("hex")
+    .slice(0, 12);
+  return `unknown-plugin-${identity}`;
+}
+
 async function findPluginSkillRoots(cacheRoot, maxDepth = 8) {
   if (!(await isDirectory(cacheRoot))) return [];
 
@@ -238,7 +250,9 @@ async function inspectCopy(skill, location, order) {
   const plugin = location.kind === "plugin-cache"
     ? await readPluginManifest(skillPath, location.cacheRoot)
     : null;
-  const namespace = plugin?.name ?? null;
+  const namespace = location.kind === "plugin-cache"
+    ? plugin?.name ?? fallbackPluginNamespace(skillPath, location.cacheRoot)
+    : null;
 
   return {
     skill,

--- a/scripts/diagnose-spuree-skill-copies.mjs
+++ b/scripts/diagnose-spuree-skill-copies.mjs
@@ -1,0 +1,352 @@
+#!/usr/bin/env node
+
+import { createHash } from "node:crypto";
+import { readFile, readdir, realpath, stat } from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const SCRIPT_PATH = fileURLToPath(import.meta.url);
+
+export const TARGET_SKILLS = Object.freeze([
+  "file-management",
+  "folder-management",
+  "getting-started",
+  "project-management",
+]);
+
+async function isDirectory(candidate) {
+  try {
+    return (await stat(candidate)).isDirectory();
+  } catch {
+    return false;
+  }
+}
+
+async function isRegularFile(candidate) {
+  try {
+    return (await stat(candidate)).isFile();
+  } catch {
+    return false;
+  }
+}
+
+function isPathContained(boundary, candidate) {
+  const relative = path.relative(boundary, candidate);
+  return relative === "" || (
+    relative !== ".." &&
+    !relative.startsWith(`..${path.sep}`) &&
+    !path.isAbsolute(relative)
+  );
+}
+
+async function containedRealpath(candidate, boundary) {
+  try {
+    const resolved = await realpath(candidate);
+    return isPathContained(boundary, resolved) ? resolved : null;
+  } catch {
+    return null;
+  }
+}
+
+function ancestors(start) {
+  const result = [];
+  let current = path.resolve(start);
+  while (true) {
+    result.push(current);
+    const parent = path.dirname(current);
+    if (parent === current) return result;
+    current = parent;
+  }
+}
+
+async function findRepositoryRoot(cwd) {
+  for (const directory of ancestors(cwd)) {
+    if (await isDirectory(path.join(directory, ".git"))) return directory;
+    if (await isRegularFile(path.join(directory, ".git"))) return directory;
+  }
+  return null;
+}
+
+async function readPluginManifest(skillPath, cacheRoot) {
+  let current = path.dirname(path.dirname(skillPath));
+  let boundary;
+  try {
+    boundary = await realpath(cacheRoot);
+  } catch {
+    return null;
+  }
+  const visited = new Set();
+
+  while (true) {
+    const currentRealpath = await containedRealpath(current, boundary);
+    if (currentRealpath === null || visited.has(currentRealpath)) break;
+    visited.add(currentRealpath);
+
+    const manifestPath = path.join(current, ".codex-plugin", "plugin.json");
+    const manifestRealpath = await containedRealpath(manifestPath, boundary);
+    if (manifestRealpath !== null && await isRegularFile(manifestRealpath)) {
+      try {
+        const manifest = JSON.parse(await readFile(manifestRealpath, "utf8"));
+        return {
+          manifestPath,
+          name: typeof manifest.name === "string" ? manifest.name : null,
+          version: typeof manifest.version === "string" ? manifest.version : null,
+        };
+      } catch {
+        return { manifestPath, name: null, version: null };
+      }
+    }
+
+    const parent = path.dirname(current);
+    if (parent === current) break;
+    current = parent;
+  }
+
+  return null;
+}
+
+async function findPluginSkillRoots(cacheRoot, maxDepth = 8) {
+  if (!(await isDirectory(cacheRoot))) return [];
+
+  let boundary;
+  try {
+    boundary = await realpath(cacheRoot);
+  } catch {
+    return [];
+  }
+
+  const roots = [];
+  const registeredSkillRoots = new Set();
+  const visited = new Set([boundary]);
+  const queue = [{
+    directory: path.resolve(cacheRoot),
+    realDirectory: boundary,
+    depth: 0,
+  }];
+  while (queue.length > 0) {
+    const { directory, realDirectory, depth } = queue.shift();
+    let entries;
+    try {
+      entries = await readdir(realDirectory, { withFileTypes: true });
+    } catch {
+      continue;
+    }
+
+    for (const entry of entries.sort((left, right) => left.name.localeCompare(right.name))) {
+      const child = path.join(directory, entry.name);
+      const realChild = await containedRealpath(
+        path.join(realDirectory, entry.name),
+        boundary,
+      );
+      if (realChild === null || !(await isDirectory(realChild))) {
+        continue;
+      }
+
+      if (entry.name === "skills") {
+        if (!registeredSkillRoots.has(realChild)) {
+          registeredSkillRoots.add(realChild);
+          roots.push(child);
+        }
+        // A semantic skills directory is a terminal discovery root. Mark its
+        // target visited even when reached through a symlink so another alias
+        // cannot turn it back into a traversal branch.
+        visited.add(realChild);
+      } else if (!visited.has(realChild) && depth < maxDepth) {
+        visited.add(realChild);
+        queue.push({
+          directory: child,
+          realDirectory: realChild,
+          depth: depth + 1,
+        });
+      }
+    }
+  }
+
+  return roots.sort();
+}
+
+function uniqueLocations(locations) {
+  const seen = new Set();
+  return locations.filter(({ root }) => {
+    const key = path.resolve(root);
+    if (seen.has(key)) return false;
+    seen.add(key);
+    return true;
+  });
+}
+
+async function candidateLocations({ cwd, home, codexHome }) {
+  const locations = [];
+  const repositoryRoot = await findRepositoryRoot(cwd);
+  if (repositoryRoot) {
+    locations.push({ root: repositoryRoot, kind: "repository" });
+  }
+
+  for (const directory of ancestors(cwd)) {
+    locations.push({ root: path.join(directory, ".agents", "skills"), kind: "project-agents" });
+    locations.push({ root: path.join(directory, ".codex", "skills"), kind: "project-codex" });
+  }
+
+  locations.push({ root: path.join(home, ".agents", "skills"), kind: "user-agents" });
+  locations.push({ root: path.join(codexHome, "skills"), kind: "user-codex" });
+
+  const cacheRoot = path.join(codexHome, "plugins", "cache");
+  for (const root of await findPluginSkillRoots(cacheRoot)) {
+    locations.push({ root, kind: "plugin-cache", cacheRoot });
+  }
+
+  return uniqueLocations(locations);
+}
+
+async function inspectCopy(skill, location, order) {
+  const skillPath = path.join(location.root, skill, "SKILL.md");
+  let readableSkillPath = skillPath;
+  if (location.kind === "plugin-cache") {
+    let boundary;
+    try {
+      boundary = await realpath(location.cacheRoot);
+    } catch {
+      return null;
+    }
+    readableSkillPath = await containedRealpath(skillPath, boundary);
+    if (readableSkillPath === null || !(await isRegularFile(readableSkillPath))) {
+      return null;
+    }
+  } else if (!(await isRegularFile(skillPath))) {
+    return null;
+  }
+
+  const bytes = await readFile(readableSkillPath);
+  const plugin = location.kind === "plugin-cache"
+    ? await readPluginManifest(skillPath, location.cacheRoot)
+    : null;
+  const namespace = plugin?.name ?? null;
+
+  return {
+    skill,
+    path: skillPath,
+    sha256: createHash("sha256").update(bytes).digest("hex"),
+    bytes: bytes.length,
+    location: location.kind,
+    catalogOrder: order,
+    namespace,
+    exposedName: namespace ? `${namespace}:${skill}` : skill,
+    plugin: plugin
+      ? {
+          name: plugin.name,
+          version: plugin.version,
+          manifestPath: plugin.manifestPath,
+        }
+      : null,
+  };
+}
+
+export async function discoverSkillCopies({
+  cwd = process.cwd(),
+  home = os.homedir(),
+  codexHome = process.env.CODEX_HOME || path.join(home, ".codex"),
+} = {}) {
+  const locations = await candidateLocations({ cwd, home, codexHome });
+  const copies = [];
+
+  for (const skill of TARGET_SKILLS) {
+    let catalogOrder = 1;
+    for (let index = 0; index < locations.length; index += 1) {
+      const copy = await inspectCopy(skill, locations[index], catalogOrder);
+      if (copy) {
+        copies.push(copy);
+        catalogOrder += 1;
+      }
+    }
+  }
+
+  copies.sort((left, right) =>
+    left.skill.localeCompare(right.skill) ||
+    left.catalogOrder - right.catalogOrder ||
+    left.path.localeCompare(right.path),
+  );
+
+  const duplicates = TARGET_SKILLS.map((skill) => {
+    const matches = copies.filter(
+      (copy) => copy.skill === skill && copy.location !== "repository",
+    );
+    return {
+      skill,
+      installedCopies: matches.length,
+      distinctHashes: new Set(matches.map((copy) => copy.sha256)).size,
+      paths: matches.map((copy) => copy.path),
+    };
+  }).filter((entry) => entry.installedCopies > 1);
+
+  return {
+    schemaVersion: 1,
+    readOnly: true,
+    resolutionNote:
+      "catalogOrder is deterministic found-copy scan order only; repository entries are references and plugin-cache entries are candidates, while the active client owns runtime skill precedence, so duplicate unprefixed names are ambiguous",
+    roots: {
+      cwd: path.resolve(cwd),
+      home: path.resolve(home),
+      codexHome: path.resolve(codexHome),
+    },
+    copies,
+    duplicates,
+  };
+}
+
+function readOption(argv, name, fallback) {
+  const index = argv.indexOf(name);
+  if (index === -1) return fallback;
+  if (!argv[index + 1]) throw new Error(`${name} requires a path`);
+  return path.resolve(argv[index + 1]);
+}
+
+function printHuman(report) {
+  console.log("Spuree skill copy diagnostic (read-only)");
+  console.log(report.resolutionNote);
+
+  for (const skill of TARGET_SKILLS) {
+    const copies = report.copies.filter((copy) => copy.skill === skill);
+    const installedOrCached = copies.filter((copy) => copy.location !== "repository");
+    const distinct = new Set(copies.map((copy) => copy.sha256)).size;
+    console.log(
+      `\n${skill}: ${installedOrCached.length} installed/cache candidate(s), ` +
+      `${copies.length - installedOrCached.length} repository reference(s), ` +
+      `${distinct} distinct hash(es)`,
+    );
+    if (copies.length === 0) {
+      console.log("  (none found)");
+      continue;
+    }
+
+    for (const copy of copies) {
+      const plugin = copy.plugin
+        ? ` plugin=${copy.plugin.name ?? "unknown"}@${copy.plugin.version ?? "unknown"}`
+        : "";
+      console.log(`  [${copy.catalogOrder}] ${copy.location}${plugin}`);
+      console.log(`      exposed=${copy.exposedName}`);
+      console.log(`      sha256=${copy.sha256}`);
+      console.log(`      path=${copy.path}`);
+    }
+  }
+}
+
+export async function main(argv = process.argv.slice(2)) {
+  const home = readOption(argv, "--home", os.homedir());
+  const report = await discoverSkillCopies({
+    cwd: readOption(argv, "--cwd", process.cwd()),
+    home,
+    codexHome: readOption(argv, "--codex-home", process.env.CODEX_HOME || path.join(home, ".codex")),
+  });
+
+  if (argv.includes("--json")) {
+    console.log(JSON.stringify(report, null, 2));
+  } else {
+    printHuman(report);
+  }
+  return 0;
+}
+
+if (process.argv[1] && path.resolve(process.argv[1]) === SCRIPT_PATH) {
+  process.exitCode = await main();
+}

--- a/test/diagnose-spuree-skill-copies.test.mjs
+++ b/test/diagnose-spuree-skill-copies.test.mjs
@@ -4,7 +4,10 @@ import os from "node:os";
 import path from "node:path";
 import test from "node:test";
 
-import { discoverSkillCopies } from "../scripts/diagnose-spuree-skill-copies.mjs";
+import {
+  discoverSkillCopies,
+  TARGET_SKILLS,
+} from "../scripts/diagnose-spuree-skill-copies.mjs";
 
 async function writeSkill(root, skill, content) {
   const skillDirectory = path.join(root, skill);
@@ -13,6 +16,18 @@ async function writeSkill(root, skill, content) {
   await writeFile(skillPath, content);
   return skillPath;
 }
+
+test("covers all seven public Spuree skills", () => {
+  assert.deepEqual(TARGET_SKILLS, [
+    "authentication",
+    "file-comment",
+    "file-management",
+    "folder-management",
+    "getting-started",
+    "project-invitation",
+    "project-management",
+  ]);
+});
 
 test("reports distinct direct and plugin copies without modifying them", async (context) => {
   const temporaryRoot = await mkdtemp(path.join(os.tmpdir(), "spuree-copy-diagnostic-"));
@@ -46,7 +61,12 @@ test("reports distinct direct and plugin copies without modifying them", async (
     })),
   );
 
-  const report = await discoverSkillCopies({ cwd: repository, home, codexHome });
+  const report = await discoverSkillCopies({
+    target: repository,
+    sourceRoot: repository,
+    home,
+    codexHome,
+  });
   assert.equal(report.readOnly, true);
   assert.match(report.resolutionNote, /runtime skill precedence/);
 
@@ -68,9 +88,14 @@ test("reports distinct direct and plugin copies without modifying them", async (
   assert.deepEqual(report.duplicates, [
     {
       skill: "file-management",
-      installedCopies: 3,
-      distinctHashes: 3,
-      paths: copies.filter((copy) => copy.location !== "repository").map((copy) => copy.path),
+      exposedName: "file-management",
+      installedCopies: 2,
+      distinctHashes: 2,
+      paths: copies
+        .filter((copy) =>
+          copy.location !== "source-reference" && copy.namespace === null
+        )
+        .map((copy) => copy.path),
     },
   ]);
 
@@ -95,7 +120,12 @@ test("reports a direct skill installed through a directory symlink without chang
   const linkPath = path.join(directRoot, "folder-management");
   await symlink(path.dirname(targetFile), linkPath, "dir");
 
-  const report = await discoverSkillCopies({ cwd: repository, home, codexHome });
+  const report = await discoverSkillCopies({
+    target: repository,
+    sourceRoot: repository,
+    home,
+    codexHome,
+  });
   const copy = report.copies.find(
     (entry) => entry.skill === "folder-management" && entry.location === "user-agents",
   );
@@ -104,6 +134,103 @@ test("reports a direct skill installed through a directory symlink without chang
   assert.equal(copy.path, path.join(linkPath, "SKILL.md"));
   assert.equal(await readlink(linkPath), path.dirname(targetFile));
   assert.equal(await readFile(targetFile, "utf8"), "linked contract\n");
+});
+
+test("keeps source, project, and user roots distinct for a repository under home", async (context) => {
+  const temporaryRoot = await mkdtemp(path.join(os.tmpdir(), "spuree-root-classification-"));
+  context.after(() => rm(temporaryRoot, { force: true, recursive: true }));
+
+  const home = path.join(temporaryRoot, "home");
+  const repository = path.join(home, "work", "repository");
+  const sourceRoot = path.join(temporaryRoot, "spuree-source");
+  const codexHome = path.join(home, ".codex");
+  await mkdir(path.join(repository, ".git"), { recursive: true });
+
+  const sourcePath = await writeSkill(sourceRoot, "folder-management", "source\n");
+  const projectPath = await writeSkill(
+    path.join(repository, ".agents", "skills"),
+    "folder-management",
+    "project\n",
+  );
+  const userPath = await writeSkill(
+    path.join(home, ".agents", "skills"),
+    "folder-management",
+    "user\n",
+  );
+
+  const report = await discoverSkillCopies({
+    target: repository,
+    sourceRoot,
+    home,
+    codexHome,
+  });
+  const byPath = new Map(
+    report.copies
+      .filter((copy) => copy.skill === "folder-management")
+      .map((copy) => [copy.path, copy]),
+  );
+
+  assert.equal(report.roots.target, repository);
+  assert.equal(report.roots.sourceRoot, sourceRoot);
+  assert.equal(byPath.get(sourcePath)?.location, "source-reference");
+  assert.equal(byPath.get(projectPath)?.location, "project-agents");
+  assert.equal(byPath.get(userPath)?.location, "user-agents");
+});
+
+test("discovers every documented client root", async (context) => {
+  const temporaryRoot = await mkdtemp(path.join(os.tmpdir(), "spuree-client-roots-"));
+  context.after(() => rm(temporaryRoot, { force: true, recursive: true }));
+
+  const repository = path.join(temporaryRoot, "repository");
+  const sourceRoot = path.join(temporaryRoot, "source");
+  const home = path.join(temporaryRoot, "home");
+  const codexHome = path.join(home, ".codex");
+  const hermesHome = path.join(temporaryRoot, "hermes-home");
+  await mkdir(path.join(repository, ".git"), { recursive: true });
+  await Promise.all(
+    TARGET_SKILLS.map((skill) => writeSkill(sourceRoot, skill, `source ${skill}\n`)),
+  );
+
+  const expectedLocations = new Map();
+  expectedLocations.set(
+    await writeSkill(path.join(repository, ".claude", "skills"), "file-comment", "project claude\n"),
+    "project-claude",
+  );
+  expectedLocations.set(
+    await writeSkill(path.join(repository, "skills"), "authentication", "project openclaw\n"),
+    "project-workspace",
+  );
+  expectedLocations.set(
+    await writeSkill(path.join(home, ".claude", "skills"), "project-invitation", "user claude\n"),
+    "user-claude",
+  );
+  expectedLocations.set(
+    await writeSkill(path.join(home, ".openclaw", "skills"), "folder-management", "user openclaw\n"),
+    "user-openclaw",
+  );
+  expectedLocations.set(
+    await writeSkill(path.join(hermesHome, "skills"), "getting-started", "user hermes\n"),
+    "user-hermes",
+  );
+
+  const report = await discoverSkillCopies({
+    target: repository,
+    sourceRoot,
+    home,
+    codexHome,
+    hermesHome,
+  });
+  const sourceSkills = report.copies
+    .filter((copy) => copy.location === "source-reference")
+    .map((copy) => copy.skill);
+  assert.deepEqual(sourceSkills, TARGET_SKILLS);
+
+  for (const [skillPath, location] of expectedLocations) {
+    assert.equal(
+      report.copies.find((copy) => copy.path === skillPath)?.location,
+      location,
+    );
+  }
 });
 
 test("discovers a contained symlinked skills root after its target was visited", async (context) => {
@@ -139,7 +266,12 @@ test("discovers a contained symlinked skills root after its target was visited",
   const linkedSkillsRoot = path.join(pluginRoot, "skills");
   await symlink(targetRoot, linkedSkillsRoot, "dir");
 
-  const report = await discoverSkillCopies({ cwd: repository, home, codexHome });
+  const report = await discoverSkillCopies({
+    target: repository,
+    sourceRoot: repository,
+    home,
+    codexHome,
+  });
   const pluginCopies = report.copies.filter(
     (copy) => copy.skill === "file-management" && copy.location === "plugin-cache",
   );
@@ -209,7 +341,12 @@ test("follows one contained plugin-root symlink without escaping or cycling", as
     "dir",
   );
 
-  const report = await discoverSkillCopies({ cwd: repository, home, codexHome });
+  const report = await discoverSkillCopies({
+    target: repository,
+    sourceRoot: repository,
+    home,
+    codexHome,
+  });
   const pluginCopies = report.copies.filter(
     (copy) => copy.skill === "file-management" && copy.location === "plugin-cache",
   );

--- a/test/diagnose-spuree-skill-copies.test.mjs
+++ b/test/diagnose-spuree-skill-copies.test.mjs
@@ -1,0 +1,236 @@
+import assert from "node:assert/strict";
+import { mkdtemp, mkdir, readFile, readlink, rm, stat, symlink, writeFile } from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import test from "node:test";
+
+import { discoverSkillCopies } from "../scripts/diagnose-spuree-skill-copies.mjs";
+
+async function writeSkill(root, skill, content) {
+  const skillDirectory = path.join(root, skill);
+  await mkdir(skillDirectory, { recursive: true });
+  const skillPath = path.join(skillDirectory, "SKILL.md");
+  await writeFile(skillPath, content);
+  return skillPath;
+}
+
+test("reports distinct direct and plugin copies without modifying them", async (context) => {
+  const temporaryRoot = await mkdtemp(path.join(os.tmpdir(), "spuree-copy-diagnostic-"));
+  context.after(() => rm(temporaryRoot, { force: true, recursive: true }));
+
+  const repository = path.join(temporaryRoot, "repository");
+  const home = path.join(temporaryRoot, "home");
+  const codexHome = path.join(temporaryRoot, "codex");
+  await mkdir(path.join(repository, ".git"), { recursive: true });
+
+  const paths = [];
+  paths.push(await writeSkill(repository, "file-management", "canonical\n"));
+  paths.push(await writeSkill(path.join(home, ".agents", "skills"), "file-management", "agents copy\n"));
+  paths.push(await writeSkill(path.join(codexHome, "skills"), "file-management", "codex copy\n"));
+
+  const pluginRoot = path.join(codexHome, "plugins", "cache", "local", "internal-spuree-skills", "0.1.1");
+  await mkdir(path.join(pluginRoot, ".codex-plugin"), { recursive: true });
+  const pluginManifestPath = path.join(pluginRoot, ".codex-plugin", "plugin.json");
+  await writeFile(
+    pluginManifestPath,
+    JSON.stringify({ name: "internal-spuree-skills", version: "0.1.1" }),
+  );
+  paths.push(pluginManifestPath);
+  paths.push(await writeSkill(path.join(pluginRoot, "skills"), "file-management", "plugin copy\n"));
+
+  const before = await Promise.all(
+    paths.map(async (skillPath) => ({
+      path: skillPath,
+      content: await readFile(skillPath, "utf8"),
+      mtimeMs: (await stat(skillPath)).mtimeMs,
+    })),
+  );
+
+  const report = await discoverSkillCopies({ cwd: repository, home, codexHome });
+  assert.equal(report.readOnly, true);
+  assert.match(report.resolutionNote, /runtime skill precedence/);
+
+  const copies = report.copies.filter((copy) => copy.skill === "file-management");
+  assert.equal(copies.length, 4);
+  assert.equal(new Set(copies.map((copy) => copy.sha256)).size, 4);
+  assert.deepEqual(copies.map((copy) => copy.catalogOrder), [...copies.map((copy) => copy.catalogOrder)].sort((a, b) => a - b));
+
+  const plugin = copies.find((copy) => copy.location === "plugin-cache");
+  assert.deepEqual(
+    { name: plugin.plugin.name, version: plugin.plugin.version, exposedName: plugin.exposedName },
+    {
+      name: "internal-spuree-skills",
+      version: "0.1.1",
+      exposedName: "internal-spuree-skills:file-management",
+    },
+  );
+
+  assert.deepEqual(report.duplicates, [
+    {
+      skill: "file-management",
+      installedCopies: 3,
+      distinctHashes: 3,
+      paths: copies.filter((copy) => copy.location !== "repository").map((copy) => copy.path),
+    },
+  ]);
+
+  for (const snapshot of before) {
+    assert.equal(await readFile(snapshot.path, "utf8"), snapshot.content);
+    assert.equal((await stat(snapshot.path)).mtimeMs, snapshot.mtimeMs);
+  }
+});
+
+test("reports a direct skill installed through a directory symlink without changing it", async (context) => {
+  const temporaryRoot = await mkdtemp(path.join(os.tmpdir(), "spuree-copy-symlink-"));
+  context.after(() => rm(temporaryRoot, { force: true, recursive: true }));
+
+  const repository = path.join(temporaryRoot, "repository");
+  const home = path.join(temporaryRoot, "home");
+  const codexHome = path.join(temporaryRoot, "codex");
+  const targetRoot = path.join(temporaryRoot, "linked-skills");
+  await mkdir(path.join(repository, ".git"), { recursive: true });
+  const targetFile = await writeSkill(targetRoot, "folder-management", "linked contract\n");
+  const directRoot = path.join(home, ".agents", "skills");
+  await mkdir(directRoot, { recursive: true });
+  const linkPath = path.join(directRoot, "folder-management");
+  await symlink(path.dirname(targetFile), linkPath, "dir");
+
+  const report = await discoverSkillCopies({ cwd: repository, home, codexHome });
+  const copy = report.copies.find(
+    (entry) => entry.skill === "folder-management" && entry.location === "user-agents",
+  );
+
+  assert(copy);
+  assert.equal(copy.path, path.join(linkPath, "SKILL.md"));
+  assert.equal(await readlink(linkPath), path.dirname(targetFile));
+  assert.equal(await readFile(targetFile, "utf8"), "linked contract\n");
+});
+
+test("discovers a contained symlinked skills root after its target was visited", async (context) => {
+  const temporaryRoot = await mkdtemp(path.join(os.tmpdir(), "spuree-skills-root-symlink-"));
+  context.after(() => rm(temporaryRoot, { force: true, recursive: true }));
+
+  const repository = path.join(temporaryRoot, "repository");
+  const home = path.join(temporaryRoot, "home");
+  const codexHome = path.join(temporaryRoot, "codex");
+  const pluginRoot = path.join(
+    codexHome,
+    "plugins",
+    "cache",
+    "source",
+    "linked-skills-plugin",
+    "1.0.0",
+  );
+  await mkdir(path.join(repository, ".git"), { recursive: true });
+  await mkdir(path.join(pluginRoot, ".codex-plugin"), { recursive: true });
+  await writeFile(
+    path.join(pluginRoot, ".codex-plugin", "plugin.json"),
+    JSON.stringify({ name: "linked-skills-plugin", version: "1.0.0" }),
+  );
+
+  // `actual-skills` sorts before `skills`, so traversal encounters and marks
+  // the real target before it reaches the semantic symlink name.
+  const targetRoot = path.join(pluginRoot, "actual-skills");
+  const targetFile = await writeSkill(
+    targetRoot,
+    "file-management",
+    "contained skills-root copy\n",
+  );
+  const linkedSkillsRoot = path.join(pluginRoot, "skills");
+  await symlink(targetRoot, linkedSkillsRoot, "dir");
+
+  const report = await discoverSkillCopies({ cwd: repository, home, codexHome });
+  const pluginCopies = report.copies.filter(
+    (copy) => copy.skill === "file-management" && copy.location === "plugin-cache",
+  );
+
+  assert.equal(pluginCopies.length, 1);
+  assert.equal(
+    pluginCopies[0].path,
+    path.join(linkedSkillsRoot, "file-management", "SKILL.md"),
+  );
+  assert.deepEqual(pluginCopies[0].plugin, {
+    name: "linked-skills-plugin",
+    version: "1.0.0",
+    manifestPath: path.join(pluginRoot, ".codex-plugin", "plugin.json"),
+  });
+  assert.equal(await readlink(linkedSkillsRoot), targetRoot);
+  assert.equal(await readFile(targetFile, "utf8"), "contained skills-root copy\n");
+});
+
+test("follows one contained plugin-root symlink without escaping or cycling", async (context) => {
+  const temporaryRoot = await mkdtemp(path.join(os.tmpdir(), "spuree-plugin-symlink-"));
+  context.after(() => rm(temporaryRoot, { force: true, recursive: true }));
+
+  const repository = path.join(temporaryRoot, "repository");
+  const home = path.join(temporaryRoot, "home");
+  const codexHome = path.join(temporaryRoot, "codex");
+  const cacheRoot = path.join(codexHome, "plugins", "cache");
+  await mkdir(path.join(repository, ".git"), { recursive: true });
+
+  const pluginTarget = path.join(cacheRoot, "zz-plugin-store");
+  await mkdir(path.join(pluginTarget, ".codex-plugin"), { recursive: true });
+  await writeFile(
+    path.join(pluginTarget, ".codex-plugin", "plugin.json"),
+    JSON.stringify({ name: "linked-spuree-skills", version: "0.2.0" }),
+  );
+  await writeSkill(
+    path.join(pluginTarget, "skills"),
+    "file-management",
+    "contained plugin copy\n",
+  );
+
+  const linkedPluginRoot = path.join(cacheRoot, "aa-linked-plugin");
+  await symlink(pluginTarget, linkedPluginRoot, "dir");
+  const cycle = path.join(pluginTarget, "cache-cycle");
+  await symlink(cacheRoot, cycle, "dir");
+
+  const escapedPlugin = path.join(temporaryRoot, "outside-plugin");
+  await mkdir(path.join(escapedPlugin, ".codex-plugin"), { recursive: true });
+  await writeFile(
+    path.join(escapedPlugin, ".codex-plugin", "plugin.json"),
+    JSON.stringify({ name: "outside-plugin", version: "9.9.9" }),
+  );
+  await writeSkill(
+    path.join(escapedPlugin, "skills"),
+    "file-management",
+    "must not be inspected\n",
+  );
+  await symlink(escapedPlugin, path.join(cacheRoot, "ab-escaped-plugin"), "dir");
+
+  const escapedSkill = await writeSkill(
+    path.join(temporaryRoot, "outside-skills"),
+    "folder-management",
+    "must not be read through a nested skill link\n",
+  );
+  await symlink(
+    path.dirname(escapedSkill),
+    path.join(pluginTarget, "skills", "folder-management"),
+    "dir",
+  );
+
+  const report = await discoverSkillCopies({ cwd: repository, home, codexHome });
+  const pluginCopies = report.copies.filter(
+    (copy) => copy.skill === "file-management" && copy.location === "plugin-cache",
+  );
+
+  assert.equal(pluginCopies.length, 1);
+  assert.equal(
+    pluginCopies[0].path,
+    path.join(linkedPluginRoot, "skills", "file-management", "SKILL.md"),
+  );
+  assert.deepEqual(pluginCopies[0].plugin, {
+    name: "linked-spuree-skills",
+    version: "0.2.0",
+    manifestPath: path.join(linkedPluginRoot, ".codex-plugin", "plugin.json"),
+  });
+  assert.equal(await readlink(linkedPluginRoot), pluginTarget);
+  assert.equal(await readlink(cycle), cacheRoot);
+  assert.equal(report.copies.some((copy) => copy.plugin?.name === "outside-plugin"), false);
+  assert.equal(
+    report.copies.some(
+      (copy) => copy.skill === "folder-management" && copy.location === "plugin-cache",
+    ),
+    false,
+  );
+});

--- a/test/diagnose-spuree-skill-copies.test.mjs
+++ b/test/diagnose-spuree-skill-copies.test.mjs
@@ -105,6 +105,60 @@ test("reports distinct direct and plugin copies without modifying them", async (
   }
 });
 
+test("keeps plugin copies with missing or corrupt manifests out of bare-name collisions", async (context) => {
+  const temporaryRoot = await mkdtemp(path.join(os.tmpdir(), "spuree-copy-invalid-plugin-"));
+  context.after(() => rm(temporaryRoot, { force: true, recursive: true }));
+
+  const repository = path.join(temporaryRoot, "repository");
+  const home = path.join(temporaryRoot, "home");
+  const codexHome = path.join(temporaryRoot, "codex");
+  const cacheRoot = path.join(codexHome, "plugins", "cache");
+  await mkdir(path.join(repository, ".git"), { recursive: true });
+  await writeSkill(repository, "folder-management", "source\n");
+  await writeSkill(path.join(home, ".agents", "skills"), "folder-management", "direct\n");
+
+  const missingRoot = path.join(cacheRoot, "local", "missing-plugin", "1.0.0");
+  const missingPath = await writeSkill(
+    path.join(missingRoot, "skills"),
+    "folder-management",
+    "missing manifest\n",
+  );
+
+  const corruptRoot = path.join(cacheRoot, "local", "corrupt-plugin", "1.0.0");
+  const corruptManifestPath = path.join(corruptRoot, ".codex-plugin", "plugin.json");
+  await mkdir(path.dirname(corruptManifestPath), { recursive: true });
+  await writeFile(corruptManifestPath, "{not-json");
+  const corruptPath = await writeSkill(
+    path.join(corruptRoot, "skills"),
+    "folder-management",
+    "corrupt manifest\n",
+  );
+
+  const report = await discoverSkillCopies({
+    target: repository,
+    sourceRoot: repository,
+    home,
+    codexHome,
+  });
+  const pluginCopies = report.copies.filter(
+    (copy) => copy.skill === "folder-management" && copy.location === "plugin-cache",
+  );
+
+  assert.equal(pluginCopies.length, 2);
+  assert.equal(new Set(pluginCopies.map((copy) => copy.namespace)).size, 2);
+  for (const copy of pluginCopies) {
+    assert.match(copy.namespace, /^unknown-plugin-[0-9a-f]{12}$/);
+    assert.notEqual(copy.exposedName, "folder-management");
+  }
+  assert.equal(pluginCopies.find((copy) => copy.path === missingPath)?.plugin, null);
+  assert.deepEqual(pluginCopies.find((copy) => copy.path === corruptPath)?.plugin, {
+    name: null,
+    version: null,
+    manifestPath: corruptManifestPath,
+  });
+  assert.deepEqual(report.duplicates, []);
+});
+
 test("reports a direct skill installed through a directory symlink without changing it", async (context) => {
   const temporaryRoot = await mkdtemp(path.join(os.tmpdir(), "spuree-copy-symlink-"));
   context.after(() => rm(temporaryRoot, { force: true, recursive: true }));

--- a/test/folder-discovery-contract.test.mjs
+++ b/test/folder-discovery-contract.test.mjs
@@ -287,21 +287,34 @@ test("rejects missing cursor replay and mismatch guidance", () => {
     changed("file", (markdown) =>
       markdown
         .replace("Replay the original `q` and every corpus-shaping filter", "Pass the cursor")
-        .replace("A malformed or mismatched bound cursor returns 422.", "Retry on cursor errors."),
+        .replace("A malformed, tampered, or mismatched bound\ncursor returns 422.", "Retry on cursor errors."),
     ),
   );
   assert(result.includes("file-management: cursor replay and mismatch semantics are missing"));
 });
 
-test("rejects hidden legacy-cursor compatibility semantics", () => {
+test("rejects missing signed cursor integrity semantics", () => {
   const result = validateFolderDiscoveryContract(
     changed("file", (markdown) =>
       markdown
-        .replace("Pre-`matchMode` legacy cursors are treated as unbound `any`-mode compatibility", "Legacy cursors work as")
-        .replace("regardless of a re-sent `matchMode`", "and inherit every re-sent match mode"),
+        .replace("Newly issued HMAC-signed `v1` cursors", "Newly issued cursors")
+        .replace("malformed, tampered, or mismatched bound", "malformed or mismatched bound"),
     ),
   );
-  assert(result.includes("file-management: legacy cursor compatibility must be explicit"));
+  assert(result.includes("file-management: signed cursor integrity semantics are missing"));
+});
+
+test("rejects an unbounded legacy-cursor migration", () => {
+  const result = validateFolderDiscoveryContract(
+    changed("file", (markdown) =>
+      markdown
+        .replace("Unsigned pre-v1 cursors are treated as unbound `any`-mode compatibility tokens", "Legacy cursors work as compatibility tokens")
+        .replace("regardless of a re-sent `matchMode`", "and inherit every re-sent match mode")
+        .replace("only until **2026-09-07 00:00 UTC**", "during migration")
+        .replace("At and after the sunset,\nevery unsigned cursor is rejected", "Unsigned cursors may remain accepted"),
+    ),
+  );
+  assert(result.includes("file-management: bounded legacy cursor migration must be explicit"));
 });
 
 test("rejects incomplete generic search status documentation", () => {

--- a/test/folder-discovery-contract.test.mjs
+++ b/test/folder-discovery-contract.test.mjs
@@ -2,6 +2,7 @@ import assert from "node:assert/strict";
 import test from "node:test";
 
 import {
+  LEGACY_CURSOR_SUNSET_ISO,
   loadSkillDocuments,
   validateFolderDiscoveryContract,
 } from "../scripts/check-folder-discovery-contract.mjs";
@@ -315,6 +316,17 @@ test("rejects an unbounded legacy-cursor migration", () => {
     ),
   );
   assert(result.includes("file-management: bounded legacy cursor migration must be explicit"));
+});
+
+test("turns the legacy-cursor sunset into an explicit maintenance failure", () => {
+  const result = validateFolderDiscoveryContract(documents, {
+    now: LEGACY_CURSOR_SUNSET_ISO,
+  });
+  assert(
+    result.includes(
+      `file-management: legacy cursor migration copy expired at ${LEGACY_CURSOR_SUNSET_ISO}; remove the unsigned-cursor compatibility guidance and update this guard`,
+    ),
+  );
 });
 
 test("rejects incomplete generic search status documentation", () => {

--- a/test/folder-discovery-contract.test.mjs
+++ b/test/folder-discovery-contract.test.mjs
@@ -389,23 +389,93 @@ test("rejects incomplete folder 400 and 503 causes", () => {
   const result = validateFolderDiscoveryContract(
     changed("folder", (markdown) =>
       markdown
-        .replace("Query has no safe high-signal term or exceeds", "Query exceeds")
-        .replace("Shared request deadline expires", "Both search branches fail"),
+        .replace("query has no safe high-signal term or exceeds", "query exceeds")
+        .replace("shared request deadline expires", "both search branches fail"),
     ),
   );
   assert(result.includes("folder-management: folder_find 400 must document unsafe low-signal queries"));
   assert(result.includes("folder-management: folder_find 503 must include the shared request deadline"));
 });
 
+test("rejects missing stable folder_find error message codes", () => {
+  const result = validateFolderDiscoveryContract(
+    changed("folder", (markdown) =>
+      markdown
+        .replace("`search_query_too_broad`", "broad query")
+        .replace("`folder_discovery_unavailable`", "temporary failure"),
+    ),
+  );
+  assert(result.includes("folder-management: folder_find 400 must identify search_query_too_broad"));
+  assert(result.includes("folder-management: folder_find 503 must identify folder_discovery_unavailable"));
+});
+
+test("rejects fallback after runtime failures or through a post-1020-only match mode", () => {
+  const result = validateFolderDiscoveryContract(
+    changed("folder", (markdown) =>
+      markdown
+        .replace(
+          "only when the client tool registry does not contain `folder_find`, or an HTTP\n   request to `GET /v1/search/folders` returns 404 or 405",
+          "whenever folder discovery fails",
+        )
+        .replace(
+          "Do not fall back after a 400, 401, 403,\n   422, 500, or 503 response, a timeout, or a network failure",
+          "Fall back after any error",
+        )
+        .replace(
+          "type=folder&searchIn=name&limit=50",
+          "type=folder&searchIn=name&matchMode=all&limit=50",
+        ),
+    ),
+  );
+  assert(result.includes("folder-management: compatibility fallback must require confirmed endpoint absence"));
+  assert(result.includes("folder-management: compatibility fallback must not mask API or transport failures"));
+  assert(result.includes("folder-management: compatibility searches must not require matchMode"));
+});
+
+test("rejects onboarding guidance that falls back without confirmed absence", () => {
+  const result = validateFolderDiscoveryContract(
+    changed("gettingStarted", (markdown) =>
+      markdown
+        .replace(
+          "Only when the tool registry lacks `folder_find`, or the endpoint returns 404 or\n405",
+          "Whenever folder discovery fails",
+        )
+        .replace(
+          "Do not fall back after another response or transport failure.",
+          "Fall back after any error.",
+        ),
+    ),
+  );
+  assert(result.includes("getting-started: compatibility fallback must be absence-only"));
+});
+
+test("rejects legacy file evidence that can introduce an unproven folder", () => {
+  const result = validateFolderDiscoveryContract(
+    changed("folder", (markdown) =>
+      markdown
+        .replace(
+          "Count a file group only when its `sessionId` is in\n   that direct-folder ID set.",
+          "Promote every file group as a folder candidate.",
+        )
+        .replace(
+          "If direct search\n   returned no folder candidates, stop",
+          "If direct search returned no folder candidates, use file evidence",
+        ),
+    ),
+  );
+  assert(result.includes("folder-management: legacy file evidence must only support proven direct folder IDs"));
+  assert(result.includes("folder-management: file evidence must not create candidates after an empty direct search"));
+});
+
 test("rejects the wrong PLOCAN compatibility-fallback leaf", () => {
   const result = validateFolderDiscoveryContract(
     changed("folder", (markdown) =>
       markdown
-        .replace("search for `Phase`", "search for `Works`")
-        .replace("do not\n   treat `Works` as the leaf", "treat `Works` as the leaf"),
+        .replace("search for\n   `Phase`", "search for\n   `Works`")
+        .replace("do not treat `Works` as the leaf", "treat `Works` as the leaf"),
     ),
   );
-  assert(result.includes("folder-management: PLOCAN fallback must target Phase 0 and Phase A beneath PLOCAN / Works"));
+  assert(result.includes("folder-management: PLOCAN fallback must preserve unverified hierarchy qualifiers"));
 });
 
 test("rejects split children arrays and legacy fallback guidance", () => {
@@ -461,7 +531,7 @@ test("rejects guidance that sends the whole request as the folder query", () => 
   const result = validateFolderDiscoveryContract(
     changed("folder", (markdown) =>
       markdown.replace(
-        "separate the likely leaf-folder stem and requested leaf labels from hierarchy\n   qualifiers.",
+        "separate the likely leaf-folder stem and requested\n   leaf labels from hierarchy qualifiers.",
         "Use the complete user request as the search query.",
       ),
     ),

--- a/test/folder-discovery-contract.test.mjs
+++ b/test/folder-discovery-contract.test.mjs
@@ -1,0 +1,470 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import {
+  loadSkillDocuments,
+  validateFolderDiscoveryContract,
+} from "../scripts/check-folder-discovery-contract.mjs";
+
+const documents = await loadSkillDocuments();
+
+function changed(key, transform) {
+  return { ...documents, [key]: transform(documents[key]) };
+}
+
+test("the distributed skills satisfy the canonical folder-discovery contract", () => {
+  assert.deepEqual(validateFolderDiscoveryContract(documents), []);
+});
+
+test("rejects an optional search query", () => {
+  const result = validateFolderDiscoveryContract(
+    changed("file", (markdown) => markdown.replace("| `q` | string | Yes |", "| `q` | string | No |")),
+  );
+  assert(result.includes("file-management: q must be explicitly required"));
+});
+
+test("rejects a non-canonical search type", () => {
+  const result = validateFolderDiscoveryContract(
+    changed("file", (markdown) =>
+      markdown.replace("`file` \\| `folder` \\| `project` \\| `asset`", "`file` \\| `folder` \\| `project` \\| `animation` \\| `asset`"),
+    ),
+  );
+  assert(result.includes("file-management: type must be exactly file|folder|project|asset|workspace"));
+});
+
+test("rejects a renamed generic search endpoint", () => {
+  const result = validateFolderDiscoveryContract(
+    changed("file", (markdown) => markdown.replace("### GET /v1/search\n", "### GET /v1/search-v2\n")),
+  );
+  assert(result.includes("file-management: missing GET /v1/search section"));
+});
+
+test("rejects generic parameter type, required, and row-set drift", () => {
+  const result = validateFolderDiscoveryContract(
+    changed("file", (markdown) =>
+      markdown
+        .replace("| `matchMode` | string | No | `any` |", "| `matchMode` | string | Yes | `any` |")
+        .replace("| `limit` | integer | No | 50 |", "| `limit` | number | No | 50 |")
+        .replace(
+          "| `format` | string | No | — |",
+          "| `legacyMode` | string | No | — | Legacy. |\n| `format` | string | No | — |",
+        ),
+    ),
+  );
+  assert(result.includes("file-management: search: parameters must be exactly q|type|searchIn|matchMode|format|entityType|workspaceId|projectId|createdAfter|createdBefore|limit|cursor|sortBy|sortOrder|includePreview in order"));
+  assert(result.includes("file-management: search: matchMode required flag must be No"));
+  assert(result.includes("file-management: search: limit type must be integer"));
+});
+
+test("rejects expanded generic enums and bounds", () => {
+  const result = validateFolderDiscoveryContract(
+    changed("file", (markdown) =>
+      markdown
+        .replace("(1–255 chars)", "(1–255 or 1–999 chars)")
+        .replace("`asc` \\| `desc`. Ignored", "`asc` \\| `desc` \\| `sideways`. Ignored"),
+    ),
+  );
+  assert(result.includes("file-management: q must document the exact 1-255 character limit"));
+  assert(result.includes("file-management: sortOrder must be exactly asc|desc"));
+});
+
+test("rejects a missing phrase match mode", () => {
+  const result = validateFolderDiscoveryContract(
+    changed("file", (markdown) =>
+      markdown.replaceAll("`phrase`", "`all`"),
+    ),
+  );
+  assert(result.includes("file-management: matchMode must be exactly any|all|phrase"));
+});
+
+test("rejects an optional or unbounded folder_find query", () => {
+  const result = validateFolderDiscoveryContract(
+    changed("folder", (markdown) =>
+      markdown
+        .replace("| `q` | string | Yes | — | Nonblank", "| `q` | string | No | — | Optional")
+        .replace("(1–255 characters)", "(any length)"),
+    ),
+  );
+  assert(result.includes("folder-management: folder_find q must be required"));
+  assert(result.includes("folder-management: folder_find q must reject blank input"));
+  assert(result.includes("folder-management: folder_find q range must be exactly 1-255"));
+});
+
+test("rejects folder_find limit and response drift", () => {
+  const result = validateFolderDiscoveryContract(
+    changed("folder", (markdown) =>
+      markdown
+        .replace("| `limit` | integer | No | 5 | Maximum canonical candidates (1–10). |", "| `limit` | integer | No | 50 | Maximum candidates. |")
+        .replace('"degradedBranches": [],', '"legacyErrors": [],'),
+    ),
+  );
+  assert(result.includes("folder-management: folder_find limit default must be 5"));
+  assert(result.includes("folder-management: folder_find limit range must be exactly 1-10"));
+  assert(result.includes("folder-management: folder_find response is missing degradedBranches"));
+});
+
+test("rejects renamed or structurally changed folder_find parameters", () => {
+  const renamed = validateFolderDiscoveryContract(
+    changed("folder", (markdown) =>
+      markdown.replace("### GET /v1/search/folders\n", "### GET /v1/search/folders-v2\n"),
+    ),
+  );
+  assert(renamed.includes("folder-management: missing GET /v1/search/folders section"));
+
+  const changedParameters = validateFolderDiscoveryContract(
+    changed("folder", (markdown) =>
+      markdown
+        .replace("| `limit` | integer | No | 5 |", "| `limit` | number | Yes | 5 |")
+        .replace(
+          "| `projectId` | string | No | — |",
+          "| `legacyProject` | string | No | — | Legacy. |\n| `projectId` | string | No | — |",
+        ),
+    ),
+  );
+  assert(changedParameters.includes("folder-management: folder_find: parameters must be exactly q|workspaceId|projectId|limit in order"));
+  assert(changedParameters.includes("folder-management: folder_find: limit type must be integer"));
+  assert(changedParameters.includes("folder-management: folder_find: limit required flag must be No"));
+});
+
+test("rejects content evidence leaked from folder_find", () => {
+  const result = validateFolderDiscoveryContract(
+    changed("folder", (markdown) =>
+      markdown.replace('"evidence": {', '"fileName": "secret.txt",\n      "evidence": {'),
+    ),
+  );
+  assert(result.includes("folder-management: folder_find response must not expose fileName"));
+});
+
+test("rejects a missing preferred one-call workflow", () => {
+  const result = validateFolderDiscoveryContract(
+    changed("folder", (markdown) =>
+      markdown.replace(
+        "GET /v1/search/folders?q={encodedNaturalLanguageQuery}&limit=5",
+        "GET /v1/folders?limit=5",
+      ),
+    ),
+  );
+  assert(result.includes("folder-management: recipe must prefer exactly one folder_find request"));
+});
+
+test("rejects missing required-nullable generic search context", () => {
+  const result = validateFolderDiscoveryContract(
+    changed("file", (markdown) =>
+      markdown.replace("| `breadcrumb` | array \\| null |", "| `legacyPath` | array \\| null |"),
+    ),
+  );
+  assert(result.includes("file-management: grouped search context is missing breadcrumb"));
+});
+
+test("rejects generic search item type and additive field drift", () => {
+  const result = validateFolderDiscoveryContract(
+    changed("file", (markdown) =>
+      markdown
+        .replace(
+          "| `score` | number | Top relevance score across this object's matches |",
+          "| `score` | string | Top relevance score across this object's matches |",
+        )
+        .replace(
+          "| `matchCount` | integer | Number of matching rows |",
+          "| `legacyScore` | number | Deprecated score. |\n| `matchCount` | integer | Number of matching rows |",
+        ),
+    ),
+  );
+  assert(result.includes("file-management: grouped search item: score type must be number"));
+  assert(result.includes("file-management: grouped search item: fields must be exactly sourceType|sourceId|score|matchCount|matches|workspaceId|projectId|sourceCreatedAt|container|project|breadcrumb in order"));
+});
+
+test("rejects expanded generic result and match enums", () => {
+  const result = validateFolderDiscoveryContract(
+    changed("file", (markdown) =>
+      markdown
+        .replace(
+          "`file` \\| `folder` \\| `project` \\| `asset` |\n| `sourceId`",
+          "`file` \\| `folder` \\| `project` \\| `asset` \\| `workspace` |\n| `sourceId`",
+        )
+        .replace(
+          "`name` \\| `body` \\| `annotation` |",
+          "`name` \\| `body` \\| `annotation` \\| `metadata` |",
+        ),
+    ),
+  );
+  assert(result.includes("file-management: grouped search sourceType must be exactly file|folder|project|asset"));
+  assert(result.includes("file-management: match rowKind must be exactly name|body|annotation"));
+});
+
+test("rejects generic match field type drift", () => {
+  const result = validateFolderDiscoveryContract(
+    changed("file", (markdown) =>
+      markdown.replace(
+        "| `snippets` | string[] | Pre-rendered HTML strings",
+        "| `snippets` | string | Pre-rendered HTML strings",
+      ),
+    ),
+  );
+  assert(result.includes("file-management: grouped search match: snippets type must be string[]"));
+});
+
+test("rejects project and breadcrumb context shape drift", () => {
+  const result = validateFolderDiscoveryContract(
+    changed("file", (markdown) =>
+      markdown
+        .replace(
+          "| `project` | `{ id: string, name: string }` |",
+          "| `project` | `{ id: string, title: string }` |",
+        )
+        .replace(
+          "sessionType: \"creative_project\" \\| \"session\"",
+          "sessionType: \"creative_project\" \\| \"session\" \\| \"animation\"",
+        ),
+    ),
+  );
+  assert(result.includes("file-management: canonical context: project shape must be { id: string, name: string }"));
+  assert(result.includes('file-management: canonical context: breadcrumb[] shape must be { id: string, name: string, sessionType: "creative_project" | "session" }'));
+});
+
+test("rejects an undocumented canonical container discriminator", () => {
+  const result = validateFolderDiscoveryContract(
+    changed("file", (markdown) =>
+      markdown.replace(
+        "Canonical object with `id`, `name`, and `kind`; `kind` is `folder` or `project`.",
+        "Opaque parent object.",
+      ),
+    ),
+  );
+  assert(result.includes("file-management: container must document id|name|kind and folder|project kinds"));
+});
+
+test("rejects nullable or partial context for file and folder hits", () => {
+  const result = validateFolderDiscoveryContract(
+    changed("file", (markdown) =>
+      markdown
+        .replace(
+          "File and folder results always carry a complete canonical\ncontext unit",
+          "File and folder results may carry a canonical context unit",
+        )
+        .replace(
+          "hits whose current lineage is missing, deleted, malformed, stale,\nor unauthorized are omitted",
+          "hits whose lineage cannot be resolved return null context",
+        ),
+    ),
+  );
+  assert(result.includes("file-management: file/folder context must be complete"));
+  assert(result.includes("file-management: unverifiable file/folder hits must be omitted"));
+});
+
+test("rejects a non-nullable sourceCreatedAt field", () => {
+  const result = validateFolderDiscoveryContract(
+    changed("file", (markdown) =>
+      markdown.replace("| `sourceCreatedAt` | datetime \\| null |", "| `sourceCreatedAt` | datetime |"),
+    ),
+  );
+  assert(result.includes("file-management: sourceCreatedAt must be nullable"));
+});
+
+test("rejects ambiguous sessionId parent semantics", () => {
+  const result = validateFolderDiscoveryContract(
+    changed("file", (markdown) =>
+      markdown.replace(
+        "For a folder or project result, `sessionId` identifies the matched\nsession itself; determine parentage only from `container` and `breadcrumb`.",
+        "For every result, `sessionId` is the parent session.",
+      ),
+    ),
+  );
+  assert(result.includes("file-management: sessionId semantics must distinguish files from sessions"));
+});
+
+test("rejects a next-page example that changes the search corpus", () => {
+  const result = validateFolderDiscoveryContract(
+    changed("file", (markdown) =>
+      markdown.replace("q=hero&type=file&cursor=<token>", "q=hero&cursor=<token>"),
+    ),
+  );
+  assert(result.includes("file-management: next-page example must replay type=file"));
+});
+
+test("rejects missing cursor replay and mismatch guidance", () => {
+  const result = validateFolderDiscoveryContract(
+    changed("file", (markdown) =>
+      markdown
+        .replace("Replay the original `q` and every corpus-shaping filter", "Pass the cursor")
+        .replace("A malformed or mismatched bound cursor returns 422.", "Retry on cursor errors."),
+    ),
+  );
+  assert(result.includes("file-management: cursor replay and mismatch semantics are missing"));
+});
+
+test("rejects hidden legacy-cursor compatibility semantics", () => {
+  const result = validateFolderDiscoveryContract(
+    changed("file", (markdown) =>
+      markdown
+        .replace("Pre-`matchMode` legacy cursors are treated as unbound `any`-mode compatibility", "Legacy cursors work as")
+        .replace("regardless of a re-sent `matchMode`", "and inherit every re-sent match mode"),
+    ),
+  );
+  assert(result.includes("file-management: legacy cursor compatibility must be explicit"));
+});
+
+test("rejects incomplete generic search status documentation", () => {
+  const result = validateFolderDiscoveryContract(
+    changed("file", (markdown) =>
+      markdown.replace("| 500 | Non-transient search or canonical-storage failure. |\n", ""),
+    ),
+  );
+  assert(result.includes("file-management: search status codes must be exactly 200|400|401|403|422|500|503"));
+});
+
+test("rejects a generic 503 without its stable message code", () => {
+  const result = validateFolderDiscoveryContract(
+    changed("file", (markdown) => markdown.replace("`search_context_unavailable`", "temporary failure")),
+  );
+  assert(result.includes("file-management: search 503 must identify search_context_unavailable"));
+});
+
+test("rejects incomplete folder status and branch-state documentation", () => {
+  const result = validateFolderDiscoveryContract(
+    changed("folder", (markdown) =>
+      markdown
+        .replace("| 500 | Non-transient search or canonical-storage failure |\n", "")
+        .replace("`ok`, `timeout`,\n`error`, or `skipped`", "`ok` or `error`"),
+    ),
+  );
+  assert(result.includes("folder-management: folder_find status codes must be exactly 200|400|401|403|422|500|503"));
+  assert(result.includes("folder-management: branch status must be exactly ok|timeout|error|skipped"));
+});
+
+test("rejects folder_find response status, branch, and evidence-value type drift", () => {
+  const result = validateFolderDiscoveryContract(
+    changed("folder", (markdown) =>
+      markdown
+        .replace('"status": "complete",', '"status": "finished",')
+        .replace('"directMatchCount": 1,', '"directMatchCount": "1",')
+        .replace(
+          '{ "branch": "file_evidence", "status": "ok" }',
+          '{ "branch": "file_matches", "status": "ok" }',
+        ),
+    ),
+  );
+  assert(result.includes("folder-management: folder_find example status must be complete|partial"));
+  assert(result.includes("folder-management: folder_find example evidence.directMatchCount must be a non-negative integer"));
+  assert(result.includes("folder-management: folder_find example branch must be direct_folder_name|file_evidence"));
+});
+
+test("rejects folder_find response schema field and type drift", () => {
+  const result = validateFolderDiscoveryContract(
+    changed("folder", (markdown) =>
+      markdown
+        .replace(
+          "| `evidence` | `directMatchCount` | integer |",
+          "| `evidence` | `directMatchCount` | string |",
+        )
+        .replace(
+          "| `result` | `evidence` | object |",
+          "| `result` | `legacyEvidence` | object |\n| `result` | `evidence` | object |",
+        ),
+    ),
+  );
+  assert(result.includes("folder-management: folder_find evidence.directMatchCount type must be integer"));
+  assert(result.includes("folder-management: folder_find response fields must exactly match the documented schema in order"));
+});
+
+test("rejects additive folder_find enum drift", () => {
+  const result = validateFolderDiscoveryContract(
+    changed("folder", (markdown) =>
+      markdown
+        .replace(
+          "| `status` | `complete` \\| `partial` |",
+          "| `status` | `complete` \\| `partial` \\| `failed` |",
+        )
+        .replace(
+          "| `matchStrength` | `exact` \\| `strong` \\| `supporting` |",
+          "| `matchStrength` | `exact` \\| `strong` \\| `supporting` \\| `uncertain` |",
+        ),
+    ),
+  );
+  assert(result.includes("folder-management: folder_find status must be exactly complete|partial"));
+  assert(result.includes("folder-management: folder_find matchStrength must be exactly exact|strong|supporting"));
+});
+
+test("rejects incomplete folder 400 and 503 causes", () => {
+  const result = validateFolderDiscoveryContract(
+    changed("folder", (markdown) =>
+      markdown
+        .replace("Query has no safe high-signal term or exceeds", "Query exceeds")
+        .replace("Shared request deadline expires", "Both search branches fail"),
+    ),
+  );
+  assert(result.includes("folder-management: folder_find 400 must document unsafe low-signal queries"));
+  assert(result.includes("folder-management: folder_find 503 must include the shared request deadline"));
+});
+
+test("rejects the wrong PLOCAN compatibility-fallback leaf", () => {
+  const result = validateFolderDiscoveryContract(
+    changed("folder", (markdown) =>
+      markdown
+        .replace("search for `Phase`", "search for `Works`")
+        .replace("do not\n   treat `Works` as the leaf", "treat `Works` as the leaf"),
+    ),
+  );
+  assert(result.includes("folder-management: PLOCAN fallback must target Phase 0 and Phase A beneath PLOCAN / Works"));
+});
+
+test("rejects split children arrays and legacy fallback guidance", () => {
+  const result = validateFolderDiscoveryContract(
+    changed("project", (markdown) =>
+      markdown.replace(
+        "Do not parse this\n> endpoint as separate collections",
+        "Fall back to the legacy { sessions: [], entities: [], files: [] } response",
+      ),
+    ),
+  );
+  assert(result.includes("project-management: children section must not recommend a legacy fallback"));
+  assert(result.includes("project-management: children section must not document split top-level arrays"));
+});
+
+test("rejects legacy Studio URLs", () => {
+  const result = validateFolderDiscoveryContract(
+    changed("folder", (markdown) =>
+      markdown.replace(
+        "https://studio.spuree.com/folders/{folderId}",
+        "https://studio.spuree.com/projects/{projectId}/folders/{folderId}",
+      ),
+    ),
+  );
+  assert(result.includes("folder: multi-segment project/folder Studio URL is forbidden"));
+});
+
+test("rejects a singular file URL in any distributed skill", () => {
+  const result = validateFolderDiscoveryContract(
+    changed("fileComment", (markdown) =>
+      markdown.replace(
+        "https://studio.spuree.com/files/{fileId}",
+        "https://studio.spuree.com/file/{fileId}",
+      ),
+    ),
+  );
+  assert(result.includes("fileComment: singular /file Studio URL is forbidden"));
+});
+
+test("rejects traversal in the bounded recipe", () => {
+  const result = validateFolderDiscoveryContract(
+    changed("folder", (markdown) =>
+      markdown.replace(
+        "Stop after the direct",
+        "GET /v1/projects/{projectId}/children\n\nStop after the direct",
+      ),
+    ),
+  );
+  assert(result.includes("folder-management: recipe must not call child endpoints"));
+});
+
+test("rejects guidance that sends the whole request as the folder query", () => {
+  const result = validateFolderDiscoveryContract(
+    changed("folder", (markdown) =>
+      markdown.replace(
+        "separate the likely leaf-folder stem and requested leaf labels from hierarchy\n   qualifiers.",
+        "Use the complete user request as the search query.",
+      ),
+    ),
+  );
+  assert(result.includes("folder-management: recipe must separate the leaf name from hierarchy qualifiers"));
+});

--- a/test/folder-discovery-contract.test.mjs
+++ b/test/folder-discovery-contract.test.mjs
@@ -480,6 +480,31 @@ test("rejects legacy file evidence that can introduce an unproven folder", () =>
   assert(result.includes("folder-management: file evidence must not create candidates after an empty direct search"));
 });
 
+test("rejects hiding the nested-file limitation of legacy evidence", () => {
+  const result = validateFolderDiscoveryContract(
+    changed("folder", (markdown) =>
+      markdown
+        .replace("Nested descendant files are a known blind spot", "Nested files count normally")
+        .replace("Treat zero direct-file evidence as inconclusive", "Treat zero evidence as a negative")
+        .replace("do not traverse descendants\n   to compensate", "traverse descendants\n   to compensate"),
+    ),
+  );
+  assert(result.includes("folder-management: nested-file evidence limitation must be explicit"));
+});
+
+test("rejects requiring matchMode for named-project discovery", () => {
+  const result = validateFolderDiscoveryContract(
+    changed("project", (markdown) =>
+      markdown.replace(
+        "type=project&searchIn=name&limit=50",
+        "type=project&searchIn=name&matchMode=all&limit=50",
+      ),
+    ),
+  );
+  assert(result.includes("project-management: named project discovery must be search-first"));
+  assert(result.includes("project-management: compatibility-safe discovery must not require matchMode"));
+});
+
 test("rejects the wrong PLOCAN compatibility-fallback leaf", () => {
   const result = validateFolderDiscoveryContract(
     changed("folder", (markdown) =>

--- a/test/folder-discovery-contract.test.mjs
+++ b/test/folder-discovery-contract.test.mjs
@@ -283,12 +283,28 @@ test("rejects a next-page example that changes the search corpus", () => {
   assert(result.includes("file-management: next-page example must replay type=file"));
 });
 
+test("rejects missing short-page cursor continuation guidance", () => {
+  const result = validateFolderDiscoveryContract(
+    changed("file", (markdown) =>
+      markdown.replace(
+        "Continue pagination whenever `cursor` is non-null, even when `count` is smaller\nthan the requested `limit`",
+        "Stop when a page is shorter than the requested limit",
+      ),
+    ),
+  );
+  assert(result.includes("file-management: short-page cursor continuation semantics are missing"));
+});
+
 test("rejects missing cursor replay and mismatch guidance", () => {
   const result = validateFolderDiscoveryContract(
     changed("file", (markdown) =>
       markdown
         .replace("Replay the original `q` and every corpus-shaping filter", "Pass the cursor")
-        .replace("A malformed, tampered, or mismatched bound\ncursor returns 422.", "Retry on cursor errors."),
+        .replace("A malformed, tampered, or mismatched bound\ncursor returns 422.", "Retry on cursor errors.")
+        .replace(
+          "permission scope changes, discard it and restart from page one with the same\nquery and filters; do not retry the rejected cursor",
+          "permission scope changes, retry the same cursor",
+        ),
     ),
   );
   assert(result.includes("file-management: cursor replay and mismatch semantics are missing"));

--- a/test/folder-discovery-contract.test.mjs
+++ b/test/folder-discovery-contract.test.mjs
@@ -427,7 +427,7 @@ test("rejects fallback after runtime failures or through a post-1020-only match 
     changed("folder", (markdown) =>
       markdown
         .replace(
-          "only when the client tool registry does not contain `folder_find`, or an HTTP\n   request to `GET /v1/search/folders` returns 404 or 405",
+          "only when the client tool registry does not contain `folder_find`, or an HTTP\n   request to `GET /v1/search/folders` returns 404, 405, or 501",
           "whenever folder discovery fails",
         )
         .replace(
@@ -450,7 +450,7 @@ test("rejects onboarding guidance that falls back without confirmed absence", ()
     changed("gettingStarted", (markdown) =>
       markdown
         .replace(
-          "Only when the tool registry lacks `folder_find`, or the endpoint returns 404 or\n405",
+          "Only when the tool registry lacks `folder_find`, or the endpoint returns 404,\n405, or 501",
           "Whenever folder discovery fails",
         )
         .replace(

--- a/test/workflow-pins.test.mjs
+++ b/test/workflow-pins.test.mjs
@@ -1,0 +1,20 @@
+import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
+import test from "node:test";
+
+const workflow = await readFile(
+  new URL("../.github/workflows/pr-tests.yml", import.meta.url),
+  "utf8",
+);
+
+function actionRefs(source) {
+  return [...source.matchAll(/^\s*(?:-\s+)?uses:\s+(\S+)/gm)].map((match) => match[1]);
+}
+
+test("PR checks pin every action and the exact Node runtime", () => {
+  assert.deepEqual(actionRefs(workflow), [
+    "actions/checkout@11d5960a326750d5838078e36cf38b85af677262",
+    "actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020",
+  ]);
+  assert.match(workflow, /^\s*node-version:\s*["']?22\.23\.2["']?\s*$/m);
+});

--- a/test/workflow-pins.test.mjs
+++ b/test/workflow-pins.test.mjs
@@ -13,8 +13,8 @@ function actionRefs(source) {
 
 test("PR checks pin every action and the exact Node runtime", () => {
   assert.deepEqual(actionRefs(workflow), [
-    "actions/checkout@11d5960a326750d5838078e36cf38b85af677262",
-    "actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020",
+    "actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1",
+    "actions/setup-node@820762786026740c76f36085b0efc47a31fe5020",
   ]);
   assert.match(workflow, /^\s*node-version:\s*["']?22\.23\.2["']?\s*$/m);
 });


### PR DESCRIPTION
## Description

Canonicalizes the public Spuree folder-discovery workflow for ENG-6307 and documents the bounded search contracts introduced by the paired CheehooData change.

### What changed

- Makes `folder_find` the preferred one-call workflow for every named-folder request, including complete/partial/degraded handling and evidence counts that never expose child content.
- Defines one bounded compatibility fallback: exactly two narrowed generic searches (folder name plus child-file evidence), with no recursive project/folder listing loop.
- Allows that legacy fallback only when the tool is absent or the endpoint explicitly reports 404, 405, or 501; authentication, validation, server, timeout, and network failures are surfaced instead of masked.
- Documents generic-search `container`, `project`, and `breadcrumb` context plus `any`, `all`, and `phrase` match modes.
- Documents the signed v1 cursor contract and the **2026-09-07 00:00 UTC** unsigned-cursor sunset.
- Standardizes canonical project, folder, asset, asset-session, and file URLs returned to users.
- Adds deterministic seven-skill contract checking, semantic install-root discovery, duplicate-copy diagnostics, and pinned CI action/Node/Codex versions.

## Dependency and rollout

- Backend contract: [CheehooData #1020](https://github.com/CheehooLabs/CheehooData/pull/1020)
- Final reviewed head: `4c7a10c3711b8a348cffa51182ceb7da1203594f`
- Merge after the Data contract is accepted. Publish/enable the skills only after the new Data fleet is fully live; see the Data PR's mixed-fleet rollout gate.

## Linear link

- [ENG-6307 — Canonicalize Spuree folder-discovery skills and deterministic drift checks](https://linear.app/cheehoo-labs-inc/issue/ENG-6307)

## Type of change

- [ ] Bug fix
- [x] New feature/documentation contract
- [ ] Breaking change

## Verification

- [x] Full public skill suite: 55/55 passed
- [x] Folder-discovery contract checker: all 7 skills passed
- [x] Workflow YAML parsing and exact runtime/action pin tests
- [x] `git diff --check`
- [x] Self-review plus independent review; all findings resolved

## Checklist

- [x] Added deterministic regression tests
- [x] Preserved public/internal capability boundaries
- [x] Documented bounded fallback, cursor migration, and canonical URLs